### PR TITLE
Refactoring woody widgets with reveal

### DIFF
--- a/library/templates/template.php
+++ b/library/templates/template.php
@@ -157,9 +157,11 @@ abstract class WoodyTheme_TemplateAbstract
         $tools_blocks = [];
 
         // Add langSwitcher
-        $tools_blocks['lang_switcher'] = $this->addLanguageSwitcher();
-        $this->context['lang_switcher'] = apply_filters('lang_switcher', $tools_blocks['lang_switcher']);
-        $this->context['lang_switcher_mobile'] = apply_filters('lang_switcher_mobile', $tools_blocks['lang_switcher']);
+        $tools_blocks['lang_switcher_button'] = $this->addLanguageSwitcherButton();
+        $this->context['lang_switcher_button'] = apply_filters('lang_switcher', $tools_blocks['lang_switcher_button']);
+        $this->context['lang_switcher_button_mobile'] = apply_filters('lang_switcher', $tools_blocks['lang_switcher_button']);
+
+        $this->context['lang_switcher_reveal'] = $this->addLanguageSwitcherReveal();
 
         // Add langSwitcher
         $tools_blocks['season_switcher'] = $this->addSeasonSwitcher();
@@ -167,9 +169,11 @@ abstract class WoodyTheme_TemplateAbstract
         $this->context['season_switcher_mobile'] = apply_filters('season_switcher_mobile', $tools_blocks['season_switcher']);
 
         // Add addEsSearchBlock
-        $tools_blocks['es_search_block'] = $this->addEsSearchBlock();
-        $this->context['es_search_block'] = apply_filters('es_search_block', $tools_blocks['es_search_block']);
-        $this->context['es_search_block_mobile'] = apply_filters('es_search_block_mobile', $tools_blocks['es_search_block']);
+        $tools_blocks['es_search_button'] = $this->addEsSearchButton();
+        $this->context['es_search_button'] = apply_filters('es_search_block', $tools_blocks['es_search_button']);
+        $this->context['es_search_button_mobile'] = apply_filters('es_search_block', $tools_blocks['es_search_button']);
+
+        $this->context['es_search_reveal'] = $this->addEsSearchReveal();
 
         // Add addFavoritesBlock
         if (in_array('favorites', $this->context['enabled_woody_options'])) {
@@ -245,13 +249,33 @@ abstract class WoodyTheme_TemplateAbstract
 
             // Set a default template
             $tpl = apply_filters('season_switcher_tpl', null);
-            $template = $tpl['template'] ? $this->context['woody_components'][$tpl['template']] : $this->context['woody_components']['woody_widgets-season_switcher-tpl_01'];
+            $template = has_filter('season_switcher_tpl') ? $this->context['woody_components'][$tpl['template']] : $this->context['woody_components']['woody_widgets-season_switcher-tpl_01'];
 
-            return Timber::compile($template, $data);
+            $return = Timber::compile($template, $data);
+            return $return;
         }
     }
 
-    private function addLanguageSwitcher()
+    private function addLanguageSwitcherButton()
+    {
+        $languages = apply_filters('woody_pll_the_languages', 'auto');
+
+        if (!empty($languages) && count($languages) != 1) {
+            $data = $this->createSwitcher($languages);
+
+            // Set a default template
+            $tpl = apply_filters('lang_switcher_button', null);
+            $template = has_filter('lang_switcher_button') ? $this->context['woody_components'][$tpl['template']] : $this->context['woody_components']['woody_widgets-lang_switcher-tpl_01'];
+
+            // Allow data override
+            $data = apply_filters('lang_switcher_data', $data);
+
+            $return = Timber::compile($template, $data);
+            return $return;
+        }
+    }
+
+    private function addLanguageSwitcherReveal()
     {
         // Get polylang languages
         $languages = apply_filters('woody_pll_the_languages', 'auto');
@@ -260,13 +284,14 @@ abstract class WoodyTheme_TemplateAbstract
             $data = $this->createSwitcher($languages);
 
             // Set a default template
-            $tpl = apply_filters('lang_switcher_tpl', null);
-            $template = $tpl['template'] ? $this->context['woody_components'][$tpl['template']] : $this->context['woody_components']['woody_widgets-lang_switcher-tpl_01'];
+            $tpl = apply_filters('lang_switcher_reveal', null);
+            $template = has_filter('lang_switcher_reveal') ? $this->context['woody_components'][$tpl['template']] : $this->context['woody_components']['reveals-lang_switcher-tpl_01'];
 
             // Allow data override
             $data = apply_filters('lang_switcher_data', $data);
 
-            return Timber::compile($template, $data);
+            $return = Timber::compile($template, $data);
+            return $return;
         }
     }
 
@@ -341,9 +366,24 @@ abstract class WoodyTheme_TemplateAbstract
         return $data;
     }
 
-    private function addEsSearchBlock()
+    private function addEsSearchButton()
     {
         $search_post_id = apply_filters('woody_get_field_option', 'es_search_page_url');
+
+        if (!empty($search_post_id)) {
+
+            // Set a default template
+            $tpl = apply_filters('es_search_button', null);
+            $template = has_filter('es_search_button') ? $tpl['template'] : $this->context['woody_components']['woody_widgets-es_search_block-tpl_01'];
+
+            return Timber::compile($template, []);
+        }
+    }
+
+    private function addEsSearchReveal()
+    {
+        $search_post_id = apply_filters('woody_get_field_option', 'es_search_page_url');
+
         if (!empty($search_post_id)) {
             $data = [];
             $data['search_url'] = get_permalink(pll_get_post($search_post_id));
@@ -373,14 +413,15 @@ abstract class WoodyTheme_TemplateAbstract
             }
 
             // Set a default template
-            $tpl = apply_filters('es_search_block_tpl', null);
-            $data['tags'] = $tpl['tags'] ?: '';
-            $template = $tpl['template'] ?: $this->context['woody_components']['woody_widgets-es_search_block-tpl_01'];
+            $tpl = apply_filters('es_search_reveal', null);
+            $template = has_filter('es_search_reveal') ? $tpl['template'] : $this->context['woody_components']['reveals-es_search_block-tpl_01'];
 
             // Allow data override
+            $data['tags'] = !empty($tpl['tags']) ? $tpl['tags'] : '';
             $data = apply_filters('es_search_block_data', $data);
 
-            return Timber::compile($template, $data);
+            $return = Timber::compile($template, $data);
+            return $return;
         }
     }
 

--- a/library/templates/template.php
+++ b/library/templates/template.php
@@ -290,8 +290,10 @@ abstract class WoodyTheme_TemplateAbstract
             // Allow data override
             $data = apply_filters('lang_switcher_data', $data);
 
-            $return = Timber::compile($template, $data);
-            return $return;
+            $compile = Timber::compile($template, $data);
+            $compile = apply_filters('lang_switcher_compile', null);
+
+            return $compile;
         }
     }
 
@@ -420,8 +422,10 @@ abstract class WoodyTheme_TemplateAbstract
             $data['tags'] = !empty($tpl['tags']) ? $tpl['tags'] : '';
             $data = apply_filters('es_search_block_data', $data);
 
-            $return = Timber::compile($template, $data);
-            return $return;
+            $compile = Timber::compile($template, $data);
+            $compile = apply_filters('es_search_compile', null);
+
+            return $compile;
         }
     }
 

--- a/views/base.twig
+++ b/views/base.twig
@@ -76,6 +76,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {% block inline_scripts %}{% endblock %}
     {# /Twig Inline Scripts tags #}
 
+    {# Reveal #}
+    {% include 'parts/reveal.twig' %}
+    {# /Reveal #}
+
     {# WP Footer #}
     {{ wp_footer }}
     {# /WP Footer #}

--- a/views/parts/header.twig
+++ b/views/parts/header.twig
@@ -3,7 +3,7 @@
         {{ season_switcher }}
     {% endif %}
 
-    {% if lang_switcher|default or es_search_block|default or subtheme_more_tools %}
+    {% if lang_switcher_button|default or es_search_button|default or subtheme_more_tools %}
         <ul class="tools list-unstyled flex-container align-middle show-for-xlarge">
             {% if subtheme_more_tools %}
                 {% for tool in subtheme_more_tools %}
@@ -22,11 +22,11 @@
             {% if favorites_block|default %}
                 <li>{{ favorites_block }}</li>
             {% endif %}
-            {% if es_search_block|default %}
-                <li>{{ es_search_block }}</li>
+            {% if es_search_button|default %}
+                <li>{{ es_search_button }}</li>
             {% endif %}
-            {% if lang_switcher|default %}
-                <li>{{ lang_switcher }}</li>
+            {% if lang_switcher_button|default %}
+                <li>{{ lang_switcher_button }}</li>
             {% endif %}
         </ul>
     {% endif %}
@@ -40,11 +40,11 @@
         {% if favorites_block_mobile|default %}
             <li>{{ favorites_block_mobile }}</li>
         {% endif %}
-        {% if es_search_block_mobile|default %}
-            <li>{{ es_search_block_mobile }}</li>
+        {% if es_search_button_mobile|default %}
+            <li>{{ es_search_button_mobile }}</li>
         {% endif %}
-        {% if lang_switcher_mobile|default %}
-            <li>{{ lang_switcher_mobile }}</li>
+        {% if lang_switcher_button_mobile|default %}
+            <li>{{ lang_switcher_button_mobile }}</li>
         {% endif %}
     </ul>
 </div>

--- a/views/parts/reveal.twig
+++ b/views/parts/reveal.twig
@@ -1,0 +1,6 @@
+{% if es_search_reveal|default %}
+    {{ es_search_reveal }}
+{% endif %}
+{% if lang_switcher_reveal|default %}
+    {{ lang_switcher_reveal }}
+{% endif %}


### PR DESCRIPTION
- Règle le pb duplication des ID sur les reveal (search et lang_switcher).
- Séparation des boutons et des reveal dans des templates distincts (Compile les reveals plus qu'une fois)
- Ajouts de filtres pour permettre de customiser site par site au besoin. 