### PR TITLE
add new acf filters

### DIFF
--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -69,13 +69,24 @@ class WoodyTheme_ACF
         add_filter('acf/load_field/key=field_5d91c4559736e', [$this, 'loadDisqusField'], 10, 3);
 
         // Custom Filter
+        add_filter('woody_get_field', [$this, 'woodyGetField'], 10, 3);
         add_filter('woody_get_field_option', [$this, 'woodyGetFieldOption'], 10, 3);
         add_filter('woody_get_field_object', [$this, 'woodyGetFieldObject'], 10, 3);
         add_filter('woody_get_fields_by_group', [$this, 'woodyGetFieldsByGroup'], 10);
-        add_filter('woody_get_post', [$this, 'woodyGetPost'], 10);
         add_filter('woody_get_fields', [$this, 'woodyGetFields'], 10);
 
         add_filter('acf/update_value', [$this, 'updateWoodyGetFields'], 10, 3);
+    }
+
+    // Récupère un champ pour l'identifiant donné
+    public function woodyGetField($field_name)
+    {
+        $woody_get_field = get_transient('woody_get_field');
+        if (empty($woody_get_field[$field_name])) {
+            $woody_get_field[$field_name] = acf_get_field($field_name);
+            set_transient('woody_get_field', $woody_get_field);
+        }
+        return $woody_get_field[$field_name];
     }
 
     public function woodyGetFieldOption($field_name)

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -31,7 +31,6 @@ class WoodyTheme_ACF
 
         add_action('acf/save_post', [$this, 'clearOptionsTransient'], 20);
 
-        add_filter('acf/update_value', [$this, 'cleanWoodyGetFields'], 10, 3);
 
         add_filter('acf/settings/load_json', [$this, 'acfJsonLoad']);
         add_filter('acf/load_field/type=radio', [$this, 'woodyTplAcfLoadField']);
@@ -72,9 +71,11 @@ class WoodyTheme_ACF
         // Custom Filter
         add_filter('woody_get_field_option', [$this, 'woodyGetFieldOption'], 10, 3);
         add_filter('woody_get_field_object', [$this, 'woodyGetFieldObject'], 10, 3);
-        add_filter('woody_get_fields_by_group', [$this, 'woodyGetFieldsByGroup'], 10, 3);
-        add_filter('woody_get_post', [$this, 'woodyGetPost'], 10, 3);
-        add_filter('woody_get_fields', [$this, 'woodyGetFields'], 10, 3);
+        add_filter('woody_get_fields_by_group', [$this, 'woodyGetFieldsByGroup'], 10);
+        add_filter('woody_get_post', [$this, 'woodyGetPost'], 10);
+        add_filter('woody_get_fields', [$this, 'woodyGetFields'], 10);
+
+        add_filter('acf/update_value', [$this, 'updateWoodyGetFields'], 10, 3);
     }
 
     public function woodyGetFieldOption($field_name)
@@ -129,6 +130,20 @@ class WoodyTheme_ACF
             set_transient('woody_get_fields', $woody_get_fields);
         }
         return $woody_get_fields[$post_id];
+    }
+
+    // Met a jours les valeurs de champs
+    public function updateWoodyGetFields($value, $post_id, $field)
+    {
+        $woody_get_fields = get_transient('woody_get_fields');
+        $old = $woody_get_fields[$post_id][$field['name']];
+
+        if ($old != $value) {
+            $woody_get_fields[$post_id][$field['name']] = $value;
+            set_transient('woody_get_fields', $woody_get_fields);
+        }
+
+        return $value;
     }
 
     /**
@@ -554,20 +569,6 @@ class WoodyTheme_ACF
         }
 
         return $current_lang;
-    }
-
-    public function cleanWoodyGetFields($value, $post_id, $field)
-    {
-        $woody_get_fields = get_transient('woody_get_fields');
-
-        $old = $woody_get_fields[$post_id][$field['name']];
-
-        if ($old != $value) {
-            $woody_get_fields[$post_id][$field['name']] = $value;
-            set_transient('woody_get_fields', $woody_get_fields);
-        }
-
-        return $woody_get_fields[$post_id][$field['name']];
     }
 
     public function cleanTransient()

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -135,7 +135,7 @@ class WoodyTheme_ACF
     // Met a jours les valeurs de champs
     public function updateWoodyGetFields($value, $post_id, $field)
     {
-        $woody_get_fields = get_transient('woody_get_fields');
+        $woody_get_fields = $this->woodyGetFields($post_id);
         $old = $woody_get_fields[$post_id][$field['name']];
 
         if ($old != $value) {

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -71,6 +71,8 @@ class WoodyTheme_ACF
         add_filter('woody_get_field_option', [$this, 'woodyGetFieldOption'], 10, 3);
         add_filter('woody_get_field_object', [$this, 'woodyGetFieldObject'], 10, 3);
         add_filter('woody_get_fields_by_group', [$this, 'woodyGetFieldsByGroup'], 10, 3);
+        add_filter('woody_get_post', [$this, 'woodyGetPost'], 10, 3);
+        add_filter('woody_get_fields', [$this, 'woodyGetFields'], 10, 3);
     }
 
     public function woodyGetFieldOption($field_name)
@@ -103,6 +105,28 @@ class WoodyTheme_ACF
             set_transient('woody_get_fields_by_group', $woody_get_fields_by_group);
         }
         return $woody_get_fields_by_group[$group_name];
+    }
+
+    // Retourne les données d'un post donné
+    public function woodyGetPost($post_id)
+    {
+        $woody_get_post = get_transient('woody_get_post');
+        if (empty($woody_get_post[$post_id])) {
+            $woody_get_post[$post_id] = get_post($post_id);
+            set_transient('woody_get_post', $woody_get_post);
+        }
+        return $woody_get_post[$post_id];
+    }
+
+    // Retourne les valeurs de champs d'un post donné
+    public function woodyGetFields($post_id)
+    {
+        $woody_get_fields = get_transient('woody_get_fields');
+        if (empty($woody_get_fields[$post_id])) {
+            $woody_get_fields[$post_id] = get_fields($post_id);
+            set_transient('woody_get_fields', $woody_get_fields);
+        }
+        return $woody_get_fields[$post_id];
     }
 
     /**
@@ -542,6 +566,10 @@ class WoodyTheme_ACF
         delete_transient('woody_website_pages_taxonomies');
         // delete_transient('woody_menus_cache');
         delete_transient('woody_get_field_option');
+        delete_transient('woody_get_field_object');
+        delete_transient('woody_get_fields_by_group');
+        delete_transient('woody_get_post');
+        delete_transient('woody_get_fields');
 
         // Warm Transient
         getWoodyTwigPaths();

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -69,7 +69,7 @@ class WoodyTheme_ACF
         add_filter('acf/load_field/key=field_5d91c4559736e', [$this, 'loadDisqusField'], 10, 3);
 
         // Custom Filter
-        add_filter('woody_get_field', [$this, 'woodyGetField'], 10, 3);
+        add_filter('woody_acf_get_field', [$this, 'woodyAcfGetField'], 10, 3);
         add_filter('woody_get_field_option', [$this, 'woodyGetFieldOption'], 10, 3);
         add_filter('woody_get_field_object', [$this, 'woodyGetFieldObject'], 10, 3);
         add_filter('woody_get_fields_by_group', [$this, 'woodyGetFieldsByGroup'], 10);
@@ -78,15 +78,15 @@ class WoodyTheme_ACF
         add_filter('acf/update_value', [$this, 'updateWoodyGetFields'], 10, 3);
     }
 
-    // Récupère un champ pour l'identifiant donné
-    public function woodyGetField($field_name)
+    // Récupère un champ pour l'identifiant donné (name, key ou ID)
+    public function woodyAcfGetField($field_name)
     {
-        $woody_get_field = get_transient('woody_get_field');
-        if (empty($woody_get_field[$field_name])) {
-            $woody_get_field[$field_name] = acf_get_field($field_name);
-            set_transient('woody_get_field', $woody_get_field);
+        $woody_acf_get_field = get_transient('woody_acf_get_field');
+        if (empty($woody_acf_get_field[$field_name])) {
+            $woody_acf_get_field[$field_name] = acf_get_field($field_name);
+            set_transient('woody_acf_get_field', $woody_acf_get_field);
         }
-        return $woody_get_field[$field_name];
+        return $woody_acf_get_field[$field_name];
     }
 
     public function woodyGetFieldOption($field_name)

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -31,6 +31,8 @@ class WoodyTheme_ACF
 
         add_action('acf/save_post', [$this, 'clearOptionsTransient'], 20);
 
+        add_filter('acf/update_value', [$this, 'cleanWoodyGetFields'], 10, 3);
+
         add_filter('acf/settings/load_json', [$this, 'acfJsonLoad']);
         add_filter('acf/load_field/type=radio', [$this, 'woodyTplAcfLoadField']);
         add_filter('acf/load_field/type=select', [$this, 'woodyIconLoadField']);
@@ -554,6 +556,20 @@ class WoodyTheme_ACF
         return $current_lang;
     }
 
+    public function cleanWoodyGetFields($value, $post_id, $field)
+    {
+        $woody_get_fields = get_transient('woody_get_fields');
+
+        $old = $woody_get_fields[$post_id][$field['name']];
+
+        if ($old != $value) {
+            $woody_get_fields[$post_id][$field['name']] = $value;
+            set_transient('woody_get_fields', $woody_get_fields);
+        }
+
+        return $woody_get_fields[$post_id][$field['name']];
+    }
+
     public function cleanTransient()
     {
         // Delete Transient
@@ -569,7 +585,7 @@ class WoodyTheme_ACF
         delete_transient('woody_get_field_object');
         delete_transient('woody_get_fields_by_group');
         delete_transient('woody_get_post');
-        delete_transient('woody_get_fields');
+        // delete_transient('woody_get_fields');
 
         // Warm Transient
         getWoodyTwigPaths();

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -136,7 +136,7 @@ class WoodyTheme_ACF
     public function updateWoodyGetFields($value, $post_id, $field)
     {
         $woody_get_fields = $this->woodyGetFields($post_id);
-        $old = $woody_get_fields[$post_id][$field['name']];
+        $old = !empty($woody_get_fields[$post_id][$field['name']]) ? $woody_get_fields[$post_id][$field['name']] : '';
 
         if ($old != $value) {
             $woody_get_fields[$post_id][$field['name']] = $value;

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -110,24 +110,13 @@ class WoodyTheme_ACF
         return $woody_get_fields_by_group[$group_name];
     }
 
-    // Retourne les données d'un post donné
-    public function woodyGetPost($post_id)
-    {
-        $woody_get_post = get_transient('woody_get_post');
-        if (empty($woody_get_post[$post_id])) {
-            $woody_get_post[$post_id] = get_post($post_id);
-            set_transient('woody_get_post', $woody_get_post);
-        }
-        return $woody_get_post[$post_id];
-    }
-
     // Retourne les valeurs de champs d'un post donné
     public function woodyGetFields($post_id)
     {
-        $woody_get_fields = get_transient('woody_get_fields');
+        $woody_get_fields = get_transient('woody_get_fields_' . $post_id);
         if (empty($woody_get_fields[$post_id])) {
             $woody_get_fields[$post_id] = get_fields($post_id);
-            set_transient('woody_get_fields', $woody_get_fields);
+            set_transient('woody_get_fields_' . $post_id, $woody_get_fields);
         }
         return $woody_get_fields[$post_id];
     }
@@ -140,7 +129,7 @@ class WoodyTheme_ACF
 
         if ($old != $value) {
             $woody_get_fields[$post_id][$field['name']] = $value;
-            set_transient('woody_get_fields', $woody_get_fields);
+            set_transient('woody_get_fields' . $post_id, $woody_get_fields);
         }
 
         return $value;


### PR DESCRIPTION
* Ajout de deux nouveaux filtres (utilise des fonctions déjà existante mais sont mis en cache)

**Retourne les données d'un post donné (get_post)**
```
add_filter('woody_get_post', [$this, 'woodyGetPost'], 10);

public function woodyGetPost($post_id)
{
    $woody_get_post = get_transient('woody_get_post');
    if (empty($woody_get_post[$post_id])) {
        $woody_get_post[$post_id] = get_post($post_id);
        set_transient('woody_get_post', $woody_get_post);
    }
    return $woody_get_post[$post_id];
}

// Exemple
apply_filters('woody_get_post', $post_id);
```

**Retourne les valeurs de champs d'un post donné (get_fields - peux être utilisé en parallèle du filtre "woody_get_post")**
```
add_filter('woody_get_fields', [$this, 'woodyGetFields'], 10);

public function woodyGetFields($post_id)
{
    $woody_get_fields = get_transient('woody_get_fields');
    if (empty($woody_get_fields[$post_id])) {
        $woody_get_fields[$post_id] = get_fields($post_id);
        set_transient('woody_get_fields', $woody_get_fields);
    }
    return $woody_get_fields[$post_id];
}

// Exemple 
$post = apply_filters('woody_get_post', $post_id);
apply_filters('woody_get_fields', $post->ID);
``` 

**Check si un champ est mise à jour dans le back-office et le met à jour dans le transient** 
```
add_filter('acf/update_value', [$this, 'updateWoodyGetFields'], 10, 3);

public function updateWoodyGetFields($value, $post_id, $field)
{
    $woody_get_fields = get_transient('woody_get_fields');
    $old = !empty($woody_get_fields[$post_id][$field['name']]) ? $woody_get_fields[$post_id][$field['name']] : '';
    if ($old != $value) {
        $woody_get_fields[$post_id][$field['name']] = $value;
        set_transient('woody_get_fields', $woody_get_fields);
    }
    return $value;
}
```