### PR TITLE
rename filters for mobile tools block

### DIFF
--- a/library/templates/template.php
+++ b/library/templates/template.php
@@ -165,7 +165,7 @@ abstract class WoodyTheme_TemplateAbstract
         // Add langSwitcher
         $tools_blocks['lang_switcher_button'] = $this->addLanguageSwitcherButton();
         $this->context['lang_switcher_button'] = apply_filters('lang_switcher', $tools_blocks['lang_switcher_button']);
-        $this->context['lang_switcher_button_mobile'] = apply_filters('lang_switcher', $tools_blocks['lang_switcher_button']);
+        $this->context['lang_switcher_button_mobile'] = apply_filters('lang_switcher_mobile', $tools_blocks['lang_switcher_button']);
 
         $this->context['lang_switcher_reveal'] = $this->addLanguageSwitcherReveal();
 
@@ -177,7 +177,7 @@ abstract class WoodyTheme_TemplateAbstract
         // Add addEsSearchBlock
         $tools_blocks['es_search_button'] = $this->addEsSearchButton();
         $this->context['es_search_button'] = apply_filters('es_search_block', $tools_blocks['es_search_button']);
-        $this->context['es_search_button_mobile'] = apply_filters('es_search_block', $tools_blocks['es_search_button']);
+        $this->context['es_search_button_mobile'] = apply_filters('es_search_block_mobile', $tools_blocks['es_search_button']);
 
         $this->context['es_search_reveal'] = $this->addEsSearchReveal();
 


### PR DESCRIPTION
* Différencier les blocs mobile des desktop (prq l'avoir fait sur les favoris et pas sur les autres ?) 
* Cas d'usage: cacher les blocs sur desktop pour les inserer dans une stickybar mais garder le comportement basique sur mobile (CF : le collet)