### PR TITLE
Page teaser media OR profile bugfix

### DIFF
--- a/acf-json/group_5b2bbb46507bf.json
+++ b/acf-json/group_5b2bbb46507bf.json
@@ -198,15 +198,9 @@
             "label": "Ajouter un média",
             "name": "page_teaser_add_media",
             "type": "true_false",
-            "instructions": "",
+            "instructions": "Ajouter un media empêche d'ajouter un profil",
             "required": 0,
-            "conditional_logic": [
-                [{
-                    "field": "field_5c614d83a4e9b",
-                    "operator": "!=",
-                    "value": "1"
-                }]
-            ],
+            "conditional_logic": [],
             "wrapper": {
                 "width": "50",
                 "class": "",
@@ -383,15 +377,9 @@
             "label": "Ajouter un profil \/ auteur",
             "name": "page_teaser_add_profile",
             "type": "true_false",
-            "instructions": "",
+            "instructions": "Ajouter un profil remplace le média ci-dessus",
             "required": 0,
-            "conditional_logic": [
-                [{
-                    "field": "field_5b44bfc2e2e21",
-                    "operator": "!=",
-                    "value": "1"
-                }]
-            ],
+            "conditional_logic": [],
             "wrapper": {
                 "width": "",
                 "class": "",
@@ -415,13 +403,7 @@
                         "field": "field_5c614d83a4e9b",
                         "operator": "==",
                         "value": "1"
-                    },
-                    {
-                        "field": "field_5b44bfc2e2e21",
-                        "operator": "!=",
-                        "value": "1"
-                    }
-                ]
+                }]
             ],
             "wrapper": {
                 "width": "",

--- a/library/templates/template-page.php
+++ b/library/templates/template-page.php
@@ -235,6 +235,13 @@ class WoodyTheme_Template_Page extends WoodyTheme_TemplateAbstract
                 $page_teaser['breadcrumb'] = $this->createBreadcrumb();
                 $page_teaser['trip_infos'] = (!empty($this->context['trip_infos'])) ? $this->context['trip_infos'] : '';
                 $page_teaser['social_shares'] = (!empty($this->context['social_shares'])) ? $this->context['social_shares'] : '';
+
+                if (!empty($page_teaser['page_teaser_add_media'])) {
+                    unset($page_teaser['profile']);
+                } elseif(!empty($page_teaser['page_teaser_add_profile'])) {
+                    unset($page_teaser['page_teaser_img']);
+                }
+
                 if (!empty($page_teaser['page_teaser_media_type']) && $page_teaser['page_teaser_media_type'] == 'map') {
                     $page_teaser['post_coordinates'] = (!empty(getAcfGroupFields('group_5b3635da6529e', $this->context['post']))) ? getAcfGroupFields('group_5b3635da6529e', $this->context['post']) : '';
                 }

--- a/src/js/admin/edit-post.js
+++ b/src/js/admin/edit-post.js
@@ -356,4 +356,11 @@ $('#post').each(function() {
         });
     })
 
+    $('.acf-field-5b44bfc2e2e21 .acf-switch:not(-on)').on('click', function() {
+        $('.acf-field-5c614d83a4e9b .acf-switch.-on').trigger('click');
+    });
+
+    $('.acf-field-5c614d83a4e9b .acf-switch:not(-on)').on('click', function() {
+        $('.acf-field-5b44bfc2e2e21 .acf-switch.-on').trigger('click');
+    });
 });


### PR DESCRIPTION
https://trello.com/c/VYHZVeTF/127-le-profil-ne-doit-pas-safficher-dans-len-t%C3%AAte-si-ajouter-un-m%C3%A9dia-est-coch%C3%A9

Il y avait une condition ACF auparavant qui faisait disparaître de l'affichage le champ profil si ajouter un média est coché, et inversement.

Cette méthode créait un problème à l'enregistrement. Le champ qui disparaissait n'était pas mis à jour (Ajouter un profil ne faisait pas passer Ajouter un media a false, le champ n'était pas mis à jour). Dans la vue front les deux apparaissaient donc.

Résolution en js 