### PR TITLE
push text only in editable span

### DIFF
--- a/src/js/admin/woody-seo.js
+++ b/src/js/admin/woody-seo.js
@@ -49,7 +49,7 @@ $('#acf-group_5d7f7cd5615c0').each(function() {
                     $tokensDiv.find('span').each(function() {
                         if ($(this).hasClass('token-val')) {
                             currentText.push($(this).data('field'));
-                        } else {
+                        } else if ($(this).hasClass('editable')) {
                             currentText.push($(this).html());
                         }
                     });


### PR DESCRIPTION
L'OT saint nazaire a rencontré un problème. Dans la meta desc il y avait d'inséré une balise <span>. 
Au niveau du code, on itère dans tous les span pour ajouter le texte. Cela créait un problème de duplication de texte.Désormais on itère plus que dans .token-val ou .editable 

