### PR TITLE
remove call to api cloudly for topics imgs

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -595,7 +595,7 @@ class WoodyTheme_WoodyGetters
 
         if (!empty($item->woody_topic_img) && !$item->woody_topic_attachment) {
             $img = [
-                'url' => rc_getImageResizedFromApi('%width%', '%height%', $item->woody_topic_img),
+                'url' =>  $item->woody_topic_img,
                 'resizer' => true
             ];
             $data['img'] = $img;


### PR DESCRIPTION
Les Images des Topics ne sont pas des images enregistrées dans wordpress donc pas d'appel possible au resizer et à Cloudly