### PR TITLE
Fix sql unpublish post

### DIFF
--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -80,8 +80,8 @@ class WoodyTheme_Unpublisher
             FROM `wp_posts`, `wp_postmeta`
             WHERE `wp_posts`.`ID` = `wp_postmeta`.`post_id`
             AND `wp_postmeta`.`meta_key` = '_wUnpublisher_date'
-            AND `wp_postmeta`.`meta_value` < {$today}
-            AND `wp_postmeta`.`meta_value` != ''"
+            AND `wp_postmeta`.`meta_value` < '{$today}'
+            AND `wp_postmeta`.`meta_value` IS NOT NULL"
         );
 
         if (!empty($results)) {


### PR DESCRIPTION
Corrige la requête sql pour les planifications de dépublication.

Rajoute des quotes sur la date du jour pour éviter les erreurs.
Remplace le != '' par IS NOT NULL car != '' prend en compte forcément tous les posts et donc ne ressort rien.

