### PR TITLE
add free ratio when icon type is img

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -413,7 +413,8 @@ class WoodyTheme_WoodyGetters
             'woody_icon' => (!empty($item['woody_icon'])) ? $item['woody_icon'] : '',
             'icon_img' => (!empty($item['icon_img']['url'])) ? [
                 'sizes' => [
-                    'thumbnail' => $item['icon_img']['sizes']['medium']
+                    'thumbnail' => $item['icon_img']['sizes']['medium'],
+                    'ratio_free' => $item['icon_img']['sizes']['ratio_free']
                 ],
                 'alt' =>  $item['icon_img']['alt'],
 


### PR DESCRIPTION
### Récupérer la taille de ratio libre lorsque le type d'icône choisi est "Image"