### PR TITLE
formating to plain text

### DIFF
--- a/src/js/admin/_index.js
+++ b/src/js/admin/_index.js
@@ -16,3 +16,4 @@ import './woody-tpl.js';
 import './ajax-load-options';
 import './ajax-load-layouts';
 import './edit-post-save-ajax';
+import './acf-wysiwyg';

--- a/src/js/admin/acf-wysiwyg.js
+++ b/src/js/admin/acf-wysiwyg.js
@@ -1,0 +1,4 @@
+acf.addFilter('wysiwyg_tinymce_settings', function(mceInit, id) {
+    mceInit.paste_as_text = true;
+    return mceInit;
+})


### PR DESCRIPTION
Force le retrait de tout le style lors du paste sur le wysiwyg. C'est peut-être un peu drastique mais cela évitera beaucoup de soucis à venir.