### PR TITLE
Override test_type for geojson files

### DIFF
--- a/library/classes/content/class-images.php
+++ b/library/classes/content/class-images.php
@@ -36,7 +36,7 @@ class WoodyTheme_Images
         add_filter('wp_handle_upload_prefilter', [$this, 'maxUploadSize']);
         add_filter('upload_mimes', [$this, 'uploadMimes'], 10, 1);
         add_filter('big_image_size_threshold', [$this, 'bigImageSizeThreshold'], 10, 4);
-        // add_filter('wp_handle_upload', [$this, 'convertFileToGeoJSON'], 100, 1);
+        add_filter('wp_handle_upload_overrides', [$this, 'handleOverridesForGeoJSON'], 10, 2);
     }
 
     public function bigImageSizeThreshold()
@@ -60,6 +60,15 @@ class WoodyTheme_Images
         $mime_types['geojson'] = 'text/plain';
 
         return $mime_types;
+    }
+
+    public function handleOverridesForGeoJSON($overrides, $file)
+    {
+        if ($file['type'] == "application/geo+json") {
+            $overrides['test_type'] = false;
+        }
+
+        return $overrides;
     }
 
     public function addImageSizes()


### PR DESCRIPTION
J'ai surchargé le test_type à l'import de fichier pour les geojson qui ne passaient plus remonté par beaucoup de monde : 

https://mantis.raccourci.fr/view.php?id=51270
https://mantis.raccourci.fr/view.php?id=51671

Quel est le soucis ? 

Dans web/wp/wp-admin/includes/file.php 
La fonction _wp_handle_upload( &$file, $overrides, $time, $action ) fait passer une batterie de tests sur les fichiers avant de les importer dans la bibliothèque. 
Dans certains cas, le "test_type" ne passe pas pour les geojson. La fonction qui va chercher l'extension du fichier ne retourne que des values false. 
L'ajout de mime_types acceptés ne suffit pas à corriger le problème. 
J'ai donc override pour ne pas passer le test quand le fichier est de type geojson via le filtre "wp_handle_upload_overrides"

Je ne trouve pas que la solution soit la plus adéquate, mais je n'arrive pas à trouver le problème de fond. En attendant, pour ne pas bloquer nos clients, cette solution fonctionne.  