### PR TITLE
add the class of hero tpl to body

### DIFF
--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -660,7 +660,10 @@ class WoodyTheme_WoodyCompilers
             $page_hero['classes'] = (!empty($page_hero['the_classes'])) ? implode(' ', $page_hero['the_classes']) : '';
 
             $page_hero = apply_filters('woody_custom_page_hero', $page_hero, $context);
-            return \Timber::compile($context['woody_components'][$page_hero['heading_woody_tpl']], $page_hero);
+            return [
+                'view' => \Timber::compile($context['woody_components'][$page_hero['heading_woody_tpl']], $page_hero),
+                'data' => $page_hero,
+            ];
         } else {
             return '';
         }

--- a/library/templates/template-page.php
+++ b/library/templates/template-page.php
@@ -243,11 +243,13 @@ class WoodyTheme_Template_Page extends WoodyTheme_TemplateAbstract
         // Compilation de l'en tête de page et du visuel et accroche pour les pages qui ne sont pas de type "accueil"
         if (!empty($page_type[0]) && $page_type[0]->slug != 'front_page') {
             $this->context['page_teaser'] = $this->compilers->formatPageTeaser($this->context);
-            $this->context['page_hero'] = $this->compilers->formatPageHero($this->context);
-            // Add class "has-hero" to body if page hero is here
-            if (!empty($this->context['page_hero'])) {
-                $this->context['body_class'] = $this->context['body_class'] . ' has-hero';
+            $page_hero = $this->compilers->formatPageHero($this->context);
+            if (!empty($page_hero)) {
+                $this->context['page_hero'] = $page_hero['view'];
+                $this->context['body_class'] = $this->context['body_class'] . ' has-hero'; // Add Class has-hero
+                $this->context['body_class'] = $this->context['body_class'] . ' has-' . $page_hero['data']['heading_woody_tpl']; // Add Class has-hero-block-tpl
             }
+            // Add class "has-hero" to body if page hero is here
         }
 
         // Si on est sur la page favoris, on ajoute un bouton pour l'impression


### PR DESCRIPTION
J'ai ajouté le tpl de hero dans les classes body sous cette forme : "has-blocks-hero-tpl_01".
Vu que cet élément est souvent le premier à être affiché sur la page, afin d'avoir des headers propres et réactifs convenables, et du fait que nous sommes souvent amenés à faire passer par dessus des éléments en fixed ou absolute, pouvoir cibler les différents tpls me semble indispensable.

Merci :)