### PR TITLE
bugfix locale

### DIFF
--- a/library/classes/timber/class-timber-filters.php
+++ b/library/classes/timber/class-timber-filters.php
@@ -239,6 +239,10 @@ class WoodyTheme_Timber_Filters
             $locale = 'fr_FR';
         }
 
+        if ($locale == 'br_BR') {
+            $locale = 'fr_FR';
+        }
+
         // https://github.com/fightbulc/moment.php
         \Moment\Moment::setLocale($locale);
         $m = new \Moment\Moment(substr($date, 0, 19));


### PR DESCRIPTION
Evite les critical errors sur le bloc socialWall en version bretonne.

(moment.php ne gère pas la locale br_BR)