### PR TITLE
[func] close and open acf fields on new posts

### DIFF
--- a/src/js/admin/_index.js
+++ b/src/js/admin/_index.js
@@ -6,6 +6,7 @@ import './move-blocks';
 import './edit-post-change-lang';
 import './edit-post-close-acf';
 // import './edit-post-model';
+import './edit-post-new-acf';
 import './edit-post-page-teaser-media';
 import './edit-post-sticky-actions';
 import './edit-post-unpublisher';

--- a/src/js/admin/edit-post-new-acf.js
+++ b/src/js/admin/edit-post-new-acf.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+
+// Corrige le problème de fermeture / ouverture des champs ACF lors de la création d'un nouveau post
+$('body.post-new-php').each(function() {
+    $('#post').each(function () {
+        $('#post-body-content').on('click', '.postbox .handle-actions .handlediv', function() {
+            if (!$(this).closest('.postbox').hasClass('closed')) {
+                $(this).attr('aria-expanded', 'false');
+                $(this).closest('.postbox').addClass('closed');
+            } else {
+                $(this).attr('aria-expanded', 'true');
+                $(this).closest('.postbox').removeClass('closed');
+            }
+        });
+    });
+});


### PR DESCRIPTION
Permet de pouvoir ouvrir et fermer les champs ACF chargés dans les nouveaux posts (sans incidence sur les posts déjà enregistrés, en brouillon ou publiés)