### PR TITLE
Fix/auto focus menu order

### DIFF
--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -456,7 +456,6 @@ class WoodyTheme_WoodyProcess
 
         // Retourne tous les posts correspondant à la query
         if ($ignore_maxnum === true) {
-            console_log($ignore_maxnum, 'ignore maxnum');
             $the_query['posts_per_page'] = -1;
         }
 
@@ -468,8 +467,6 @@ class WoodyTheme_WoodyProcess
 
         // On ajoute la tax_query
         $the_query['tax_query'] = (!empty($tax_query)) ? $tax_query : '';
-
-        console_log($the_query['tax_query']);
 
         // Si Hiérarchie = Enfants directs de la page
         // On passe le post ID dans le paramètre post_parent de la query
@@ -497,8 +494,6 @@ class WoodyTheme_WoodyProcess
 
         // On créé la wp_query avec les paramètres définis
         $query_result = new \WP_Query($the_query);
-
-        console_log($query_result, 'query result');
 
         // Si on ordonne par geoloc, il faut trier les résultats reçus
         $query_result = apply_filters('custom_process_woody_query', $query_result, $query_form, $the_post);

--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -422,7 +422,7 @@ class WoodyTheme_WoodyProcess
                 $order = 'ASC';
                 break;
             case 'menu_order':
-                $orderby = 'menu_order';
+                $orderby = 'post_parent menu_order ID';
                 $order = 'ASC';
                 break;
             default:
@@ -456,6 +456,7 @@ class WoodyTheme_WoodyProcess
 
         // Retourne tous les posts correspondant à la query
         if ($ignore_maxnum === true) {
+            console_log($ignore_maxnum, 'ignore maxnum');
             $the_query['posts_per_page'] = -1;
         }
 
@@ -467,6 +468,8 @@ class WoodyTheme_WoodyProcess
 
         // On ajoute la tax_query
         $the_query['tax_query'] = (!empty($tax_query)) ? $tax_query : '';
+
+        console_log($the_query['tax_query']);
 
         // Si Hiérarchie = Enfants directs de la page
         // On passe le post ID dans le paramètre post_parent de la query
@@ -494,6 +497,8 @@ class WoodyTheme_WoodyProcess
 
         // On créé la wp_query avec les paramètres définis
         $query_result = new \WP_Query($the_query);
+
+        console_log($query_result, 'query result');
 
         // Si on ordonne par geoloc, il faut trier les résultats reçus
         $query_result = apply_filters('custom_process_woody_query', $query_result, $query_form, $the_post);


### PR DESCRIPTION
Fix des mises en avant auto et lists grid avec "Suivre l'ordre défini dans Woody Pages" :

Anciennement, le $orderby ne se faisait que sur le menu_order : de nombreux posts possédaient le même et étaient regroupés alors qu'ils n'étaient pas du tout au même endroit.

**3 paramètres** mis au $orderby pour cette option :

- On check d'abord le **post_parent** pour regrouper les pages qui se trouvent au même niveau au même endroit
- Les posts sont ensuite classés en fonction de leur **menu_order** (plus de valeur similaires vu qu'on a regroupé les posts en fonction de leur parent)
- On vérifie en dernier l'**ID** de page si jamais les deux paramètres précédents n'ont pas été suffisants : c'est surtout une sécurité pour ranger les pages de niveau 1 (qui sont rarement dans des mises en avant, encore moins dans des mises en avant auto, et encore moins avec cette option pour changer leur ordre)