### PR TITLE
[fix] existing padding with breakpoint classes

### DIFF
--- a/acf-json/group_5b461a3831284.json
+++ b/acf-json/group_5b461a3831284.json
@@ -316,8 +316,8 @@
                 "id": ""
             },
             "choices": {
-                "padd-all-lg": "Grande",
-                "padd-all-xlg": "Très Grande"
+                "padd-lg": "Grande",
+                "padd-xlg": "Très Grande"
             },
             "allow_null": 1,
             "default_value": "",


### PR DESCRIPTION
Changement de la valeur envoyée par les padding sur genericBloc, en lien avec la modification des classes concernées sur la librairie (padding et margin avec breakpoint).
Les valeurs qui étaient déjà saisies dans ce champs restent fonctionnelles, comme les deux classes ont bien été ajoutés à la librairie.