### PR TITLE
[fix] display author in landswiper

### DIFF
--- a/library/templates/template-page.php
+++ b/library/templates/template-page.php
@@ -143,6 +143,7 @@ class WoodyTheme_Template_Page extends WoodyTheme_TemplateAbstract
 
                     if (!empty($slide['landswpr_slide_media']) && $slide['landswpr_slide_media']['landswpr_slide_media_type'] == 'img' && !empty($slide['landswpr_slide_media']['landswpr_slide_img'])) {
                         $home_slider['landswpr_slides'][$slide_key]['landswpr_slide_media']['landswpr_slide_img']['lazy'] = 'disabled';
+                        $home_slider['landswpr_slides'][$slide_key]['landswpr_slide_media']['landswpr_slide_img']['attachment_more_data'] = $this->tools->getAttachmentMoreData($home_slider['landswpr_slides'][$slide_key]['landswpr_slide_media']['landswpr_slide_img']['ID']);
                     }
 
                     if (!empty($slide['landswpr_slide_add_social_movie']) && !empty($slide['landswpr_slide_social_movie'])) {


### PR DESCRIPTION
Permet d'afficher l'auteur sur les slides dans les blocs de type "Diaporama".

Correctif suite au recettage de Rochefort-en-Terre.