### PR TITLE
Feature/current season option

### DIFF
--- a/acf-json/group_season_settings.json
+++ b/acf-json/group_season_settings.json
@@ -1,0 +1,60 @@
+{
+    "key": "group_season_settings",
+    "title": "Seasons Settings",
+    "fields": [
+        {
+            "key": "field_5ef9d742f128d",
+            "label": "Saison courante",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_5ef9d742f128e",
+            "label": "Changer la saison courante",
+            "name": "current_season",
+            "type": "radio",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {},
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "",
+            "layout": "horizontal",
+            "return_format": "value",
+            "save_other_choice": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": ""
+}

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -1136,6 +1136,9 @@ class WoodyTheme_ACF
                     // On met à jour la "saison prioritaire" pour le calcul des canoniques
                     update_option('woody_season_priority', $current_season_field);
 
+                    // On flush le varnish
+                    do_action('woody_flush_varnish');
+
                     // On lance un rsdu
                     do_action('woody_async_add', 'woody_hawwwai_rsdu');
 

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -1127,8 +1127,18 @@ class WoodyTheme_ACF
 
                 // Si la valeur du champ est différente de l'option active
                 if (!empty($current_season_field) && !empty($polylang_option) && $current_season_field !== $polylang_option['default_lang']) {
-                    $polylang_option['default_lang'] = $current_season_field; // On change la default_lang
-                    update_option('polylang', $polylang_option); // Update option polylang
+                    // On change la default_lang dans le tableau d'options polylang
+                    $polylang_option['default_lang'] = $current_season_field;
+
+                    // On met à jour les options polylang avec le précédent tableau
+                    update_option('polylang', $polylang_option);
+
+                    // On met à jour la "saison prioritaire" pour le calcul des canoniques
+                    update_option('woody_season_priority', $current_season_field);
+
+                    // On lance un rsdu
+                    do_action('woody_async_add', 'woody_hawwwai_rsdu');
+
                     // On redirige vers la page d'option dans la langue qui vient d'être enregistrée
                     wp_redirect(admin_url() . 'admin.php?page=woody-settings&lang=' . $current_season_field);
                     exit;

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -68,6 +68,8 @@ class WoodyTheme_ACF
 
         add_filter('acf/load_field/name=tags_primary', [$this, 'addPrimaryTagsFields'], 10, 3);
         add_filter('acf/load_field/name=active_shares', [$this, 'addSocialChoices'], 10, 3);
+        add_filter('acf/load_fields', [$this, 'addSeasonChoices'], 10, 3);
+        add_filter('acf/update_value', [$this, 'updateCurrentSeason'], 10, 3);
 
         // Custom Filter
         add_filter('woody_get_field_option', [$this, 'woodyGetFieldOption'], 10, 3);
@@ -1067,5 +1069,72 @@ class WoodyTheme_ACF
         };
 
         return $field;
+    }
+
+    public function addSeasonChoices($fields, $parent)
+    {
+        // Si on est dans la page Paramètres
+        if ($parent['key'] == 'group_5c0fed3541b45') {
+            $seasons = apply_filters('woody_pll_the_seasons', 'auto');
+
+            // S'il y a des saisons
+            if (!empty($seasons)) {
+                // On récupère le group de paramètres de saison
+                $season_settings_fields = acf_get_fields('group_season_settings');
+
+                // Si les choices sont vides
+                if (empty($season_settings_fields[1]['choices'])) {
+                    // On traite chaque saison
+                    foreach ($seasons as $season) {
+                        // Saison courante
+                        if ($season['current_lang'] == true) {
+                            // Traitement pour toujours avoir la saison courant en premier
+                            if (empty($season_settings_fields[1]['choices'])) {
+                                // Si les choices sont vides, on l'ajoute directement
+                                $season_settings_fields[1]['choices'][$season['slug']] = $season['name'];
+                            } else {
+                                // S'il y a déjà des choices, on l'ajoute avant ceux-ci
+                                $current_lang_choice = [$season['slug'] => $season['name']];
+                                $season_settings_fields[1]['choices'] = $current_lang_choice + $season_settings_fields[1]['choices'];
+                            }
+                            // Default value sur la saison courante
+                            $season_settings_fields[1]['default_value'] = $season['slug'];
+                            // On met à jour le champ pour être sûr que la saison courante est sélectionnée de base
+                            update_field('current_season', $season['slug'], 'options');
+                        } else {
+                            // Saison non-courante
+                            $season_settings_fields[1]['choices'][$season['slug']] = $season['name'];
+                        }
+                    }
+                };
+
+                // On ajoute les champs de paramètres de saison
+                $fields = array_merge($fields, $season_settings_fields);
+            }
+        }
+
+        return $fields;
+    }
+
+    public function updateCurrentSeason($value, $post_id, $field)
+    {
+        // Si on est dans la page paramètres
+        if ($post_id == 'options') {
+            // S'il s'agit du champ de saison courante
+            if ($field['name'] == 'current_season') {
+                $current_season_field = $value; // Valeur du champ
+                $polylang_option = get_option('polylang'); // Option polylang
+
+                // Si la valeur du champ est différente de l'option active
+                if ($current_season_field !== $polylang_option['default_lang']) {
+                    $polylang_option['default_lang'] = $current_season_field; // On change la default_lang
+                    update_option('polylang', $polylang_option); // Update option polylang
+                    wp_redirect(admin_url() . '/admin.php?page=woody-settings&lang=' . $current_season_field);
+                    exit;
+                }
+            }
+        }
+
+        return $value;
     }
 }

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -1119,17 +1119,18 @@ class WoodyTheme_ACF
     public function updateCurrentSeason($value, $post_id, $field)
     {
         // Si on est dans la page paramètres
-        if ($post_id == 'options') {
+        if (!empty($post_id) && $post_id == 'options') {
             // S'il s'agit du champ de saison courante
-            if ($field['name'] == 'current_season') {
+            if (!empty($field['name']) && $field['name'] == 'current_season') {
                 $current_season_field = $value; // Valeur du champ
                 $polylang_option = get_option('polylang'); // Option polylang
 
                 // Si la valeur du champ est différente de l'option active
-                if ($current_season_field !== $polylang_option['default_lang']) {
+                if (!empty($current_season_field) && !empty($polylang_option) && $current_season_field !== $polylang_option['default_lang']) {
                     $polylang_option['default_lang'] = $current_season_field; // On change la default_lang
                     update_option('polylang', $polylang_option); // Update option polylang
-                    wp_redirect(admin_url() . '/admin.php?page=woody-settings&lang=' . $current_season_field);
+                    // On redirige vers la page d'option dans la langue qui vient d'être enregistrée
+                    wp_redirect(admin_url() . 'admin.php?page=woody-settings&lang=' . $current_season_field);
                     exit;
                 }
             }

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -68,7 +68,7 @@ class WoodyTheme_ACF
 
         add_filter('acf/load_field/name=tags_primary', [$this, 'addPrimaryTagsFields'], 10, 3);
         add_filter('acf/load_field/name=active_shares', [$this, 'addSocialChoices'], 10, 3);
-        add_filter('acf/load_fields', [$this, 'addSeasonChoices'], 10, 3);
+        add_filter('acf/load_fields', [$this, 'addSeasonChoices'], 10, 2);
         add_filter('acf/update_value', [$this, 'updateCurrentSeason'], 10, 3);
 
         // Custom Filter


### PR DESCRIPTION
### Option de changement de saison

_Si le site possède des saisons, on ajoute un nouvel onglet dans la page paramètres avec les deux saisons "principales"._

Celle qui est actuellement active est cochée de base, pour éviter que la mise à jour de la page suite au changement d'une autre option crée un changement de saison non souhaité.
**Plusieurs sécurités mises en place :**
- changement de la **default value**
- saison courante **placée en première** parmi les boutons radio
- **update field** sur le champ radio

Au moment de l'enregistrement de ce champ, si sa valeur est différente par rapport à la langue par défaut définie dans les options polylang :
- On met à jour l'**option polylang** avec cette nouvelle valeur (// changement de la langue par défaut)
- On met à jour l'**option de saison prioritaire** (// langue prioritaire pour le calcul des canoniques)
- On lance un **rsdu** en async
- On **redirige** vers la page de paramètres avec la nouvelle langue passée en GET (comme cette page n'est accessible que dans la langue par défaut)

### A confirmer :

- Utilisation d'un filtre assez large **_'acf/load_fields'_** pour ensuite cibler la fonction sur la page Paramètres, et avoir la possibilité d'ajouter deux champs acf à cet endroit là (onglet et select radio), plutôt que d'ajouter ces champs acf de base et les cacher ensuite (au load-field de chacun de ces champs) si on se rend compte qu'il n'y a pas de saisons.
- Utilisation d'un autre filtre assez large _**'acf/update-value'**_ pour aussi cibler la fonction sur la page Paramètres, et plus particulièrement le champ **"current_season"**, pour pouvoir réaliser les modifications souhaitées lorsque ce champ est mis à jour.

