### PR TITLE
[func] move Mise en page tab for Liste de contenus & fix togge paddin…

### DIFF
--- a/acf-json/group_5bc6005838259.json
+++ b/acf-json/group_5bc6005838259.json
@@ -2,156 +2,34 @@
     "key": "group_5bc6005838259",
     "title": "Elements de liste",
     "fields": [{
-            "key": "field_5bc60342c66b8",
-            "label": "Contenu",
-            "name": "",
-            "type": "tab",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "placement": "top",
-            "endpoint": 0
+        "key": "field_5bc60269d172d",
+        "label": "Requête",
+        "name": "list_el_req_fields",
+        "type": "clone",
+        "instructions": "",
+        "required": 0,
+        "conditional_logic": 0,
+        "wrapper": {
+            "width": "",
+            "class": "hide-label",
+            "id": ""
         },
-        {
-            "key": "field_5bc60269d172d",
-            "label": "Requête",
-            "name": "list_el_req_fields",
-            "type": "clone",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "hide-label",
-                "id": ""
-            },
-            "clone": [
-                "field_5b27890c84ed3",
-                "field_5b27a02e9d7c5",
-                "field_5b27a25103e43",
-                "field_5b28d791038fa",
-                "field_5b27a67203e48",
-                "field_5b27a3d703e44",
-                "field_5b2917f0ff061",
-                "field_5c814940fba28",
-                "field_5b88eae6c0adc"
-            ],
-            "display": "group",
-            "layout": "block",
-            "prefix_label": 0,
-            "prefix_name": 0
-        },
-        {
-            "key": "field_5bc60356c66b9",
-            "label": "Mise en page",
-            "name": "",
-            "type": "tab",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "placement": "top",
-            "endpoint": 0
-        },
-        {
-            "key": "field_5cdec09776c95",
-            "label": "Templates",
-            "name": "",
-            "type": "accordion",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "open": 0,
-            "multi_expand": 0,
-            "endpoint": 0
-        },
-        {
-            "key": "field_5bc60362c66ba",
-            "label": "Template",
-            "name": "listgrid_woody_tpl",
-            "type": "text",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "default_value": "blocks-focus-tpl_103",
-            "placeholder": "",
-            "prepend": "",
-            "append": "",
-            "maxlength": ""
-        },
-        {
-            "key": "button_field_5bc60362c66ba",
-            "label": "Choisir une mise en page",
-            "name": "",
-            "type": "message",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "hide-label woody-tpl-button group_5bc6005838259",
-                "id": ""
-            },
-            "message": "Choisir une mise en page",
-            "new_lines": "wpautop",
-            "esc_html": 0
-        },
-        {
-            "key": "field_5cdec0a976c96",
-            "label": "Options avancées",
-            "name": "",
-            "type": "accordion",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "open": 0,
-            "multi_expand": 0,
-            "endpoint": 0
-        },
-        {
-            "key": "field_5cdec0ba76c97",
-            "label": "Retirer les marges autour des mises en avant",
-            "name": "list_no_padding",
-            "type": "true_false",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "message": "",
-            "default_value": 0,
-            "ui": 1,
-            "ui_on_text": "",
-            "ui_off_text": ""
-        }
-    ],
+        "clone": [
+            "field_5b27890c84ed3",
+            "field_5b27a02e9d7c5",
+            "field_5b27a25103e43",
+            "field_5b28d791038fa",
+            "field_5b27a67203e48",
+            "field_5b27a3d703e44",
+            "field_5b2917f0ff061",
+            "field_5c814940fba28",
+            "field_5b88eae6c0adc"
+        ],
+        "display": "group",
+        "layout": "block",
+        "prefix_label": 0,
+        "prefix_name": 0
+    }],
     "location": [
         [{
             "param": "post_type",

--- a/acf-json/group_5bc6ece98595c.json
+++ b/acf-json/group_5bc6ece98595c.json
@@ -1,8 +1,7 @@
 {
     "key": "group_5bc6ece98595c",
     "title": "Liste",
-    "fields": [
-        {
+    "fields": [{
             "key": "field_5bc6ed66bea43",
             "label": "Elements à lister",
             "name": "",
@@ -114,6 +113,128 @@
             "prefix_name": 0
         },
         {
+            "key": "field_5bc60356c66b9",
+            "label": "Mise en page",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 0
+        },
+        {
+            "key": "field_5cdec09776c95",
+            "label": "Template",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 0
+        },
+        {
+            "key": "field_5bc60362c66ba",
+            "label": "Template",
+            "name": "listgrid_woody_tpl",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "blocks-focus-tpl_103",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "button_field_5bc60362c66ba",
+            "label": "Choisir une mise en page",
+            "name": "",
+            "type": "message",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "hide-label woody-tpl-button group_5bc6005838259",
+                "id": ""
+            },
+            "message": "Choisir une mise en page",
+            "new_lines": "wpautop",
+            "esc_html": 0
+        },
+        {
+            "key": "field_5cdec0a976c96",
+            "label": "Options avancées",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 0
+        },
+        {
+            "key": "field_5cdec0ba76c97",
+            "label": "Retirer les marges autour des mises en avant",
+            "name": "list_no_padding",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_5e68Zse2f3t1c",
+            "label": "FIN",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 1
+        },
+        {
             "key": "field_61d419c11e776",
             "label": "Responsive",
             "name": "",
@@ -152,13 +273,11 @@
         }
     ],
     "location": [
-        [
-            {
-                "param": "post_type",
-                "operator": "==",
-                "value": "post"
-            }
-        ]
+        [{
+            "param": "post_type",
+            "operator": "==",
+            "value": "post"
+        }]
     ],
     "menu_order": 0,
     "position": "normal",

--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -414,11 +414,13 @@ class WoodyTheme_WoodyCompilers
             $the_items['empty'] = __('Désolé, aucun contenu ne correspond à votre recherche', 'woody-theme');
         }
 
+        $the_items['no_padding'] = (!empty($wrapper['list_no_padding'])) ? $wrapper['list_no_padding'] : '';
+
         // Show button
         $the_items['display_button'] = (!empty($list_el_wrapper['display_button'])) ? $list_el_wrapper['display_button'] : false;
 
         // On compile la grille des éléments
-        $the_list['the_grid'] = \Timber::compile($twigPaths[$wrapper['the_list_elements']['listgrid_woody_tpl']], $the_items);
+        $the_list['the_grid'] = \Timber::compile($twigPaths[$wrapper['listgrid_woody_tpl']], $the_items);
 
         // On récupère le nombre de résultats
         $the_list = $this->tools->countFocusResults($the_items, $the_list);


### PR DESCRIPTION
### Blocs "Liste de contenus"

- On déplace l'onglet "Mise en page" car il était trop caché ([cf tâche ClickUp](https://app.clickup.com/t/1dv8hwj)).
- Ajout de la gestion de "Retirer les marges autour des mises en avant" qui ne fonctionnait pas jusqu'à présent.

Je sais pas si c'est risqué de déplacer le champ "Mise en page" étant donné qu'il était dans le clone 'the_list_elements' ? Est-ce que ça va pas masquer les blocs existants vu que la valeur de la meta sera différente ?