### PR TITLE
[func] add site name in menu logo

### DIFF
--- a/library/templates/template.php
+++ b/library/templates/template.php
@@ -120,6 +120,10 @@ abstract class WoodyTheme_TemplateAbstract
         if (empty($this->globals['is_mobile'])) {
             $this->globals['is_mobile'] = (WP_ENV == 'dev' || is_user_logged_in()) ? null : wp_is_mobile();
         }
+
+        if (empty($this->globals['site_name'])) {
+            $this->globals['site_name'] = get_bloginfo('name');
+        }
     }
 
     private function getAncestors($post)

--- a/views/page.twig
+++ b/views/page.twig
@@ -17,6 +17,7 @@
                     {% else %}
                         <div class="mobile-header hide-for-xlarge title-bar">
                             <span class="brand-logo obf" data-obf="{{ home_url|base64Encode }}">
+                                <span class="no-visible-text menu-logo-site-name isAbs">{{ globals.site_name|default }}</span>
                                 {{ mobile_logo|default(website_logo) }}
                             </span>
                         </div>

--- a/views/page404.twig
+++ b/views/page404.twig
@@ -5,6 +5,7 @@
     <div class="content-wrapper {{ page_terms|default('no-terms') }}">
         <div class="mobile-header hide-for-xlarge title-bar">
             <div class="brand-logo obf" data-obf="{{ home_url|base64Encode }}">
+                <span class="no-visible-text menu-logo-site-name isAbs">{{ globals.site_name|default }}</span>
                 {{ website_logo|default('Website logo') }}
             </div>
         </div>


### PR DESCRIPTION
Ajout du nom du site dans le logo du menu pour augmenter l'accessibilité des sites.

À merger avec :

https://github.com/woody-wordpress-pro/woody-library/pull/559