### PR TITLE
[FUNC] Add link to eye_candy_img

### DIFF
--- a/acf-json/group_5db057d2910e2.json
+++ b/acf-json/group_5db057d2910e2.json
@@ -43,6 +43,27 @@
             "mime_types": "jpg, jpeg, gif, png"
         },
         {
+            "key": "field_5b04231f7d07c",
+            "label": "Lien",
+            "name": "eye_candy_img_link",
+            "type": "link",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [{
+                    "field": "field_5bd80bae735cb",
+                    "operator": "==",
+                    "value": "link"
+                }]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array"
+        },
+        {
             "key": "field_61d406710984f",
             "label": "Responsive",
             "name": "",

--- a/acf-json/group_5db057d2910e2.json
+++ b/acf-json/group_5db057d2910e2.json
@@ -47,7 +47,7 @@
             "label": "Lien",
             "name": "eye_candy_img_link",
             "type": "link",
-            "instructions": "",
+            "instructions": "Si renseigné, le clic sur le visuel renverra vers ce lien",
             "required": 0,
             "conditional_logic": [
                 [{


### PR DESCRIPTION
**Demande liée au [ticket 0058692](https://mantis.raccourci.fr/view.php?id=58692)**

Ajout d'un champs link au bloc de Logo / Image d'illustration.

_**[Pull Request liée](https://github.com/woody-wordpress-pro/woody-library/pull/585#issue-1354035198)**_