### PR TITLE
Feature/retry class unpublisher

### DIFF
--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -18,10 +18,10 @@ class WoodyTheme_Unpublisher
     protected function registerHooks()
     {
         add_action('add_meta_boxes', array($this, 'registerMetaBox'));
-        // add_action('save_post', array($this, 'saveUnpublisherParams'));
+        add_action('save_post', array($this, 'saveUnpublisherParams'));
 
         add_action('woody_theme_update', [$this, 'scheduleUnpublishPosts']);
-        // add_action('woody_unpublish_posts', [$this, 'woodyUnpublishPosts']);
+        add_action('woody_unpublish_posts', [$this, 'woodyUnpublishPosts']);
     }
 
     public function registerMetaBox()
@@ -29,6 +29,7 @@ class WoodyTheme_Unpublisher
         $post_types = get_post_types(['public' => true, '_builtin' => false]);
         $post_types['page'] = 'page';
 
+        // TODO: add apply filters
         $exclude = ['short_link', 'snowflake_config', 'testimony', 'touristic_sheet', 'woody_model', 'woody_section_model'];
 
         foreach ($post_types as $post_type) {
@@ -60,54 +61,55 @@ class WoodyTheme_Unpublisher
         echo '<div><small><i>À compter de la date choisie (+/- 1h), le contenu passe en brouillon</div></small></i>';
     }
 
-    // public function saveUnpublisherParams($post_id)
-    // {
-    //     if (!isset($_POST['saveUnpublisherParams_nonce'])) {
-    //         return $post_id;
-    //     }
+    public function saveUnpublisherParams($post_id)
+    {
+        if (!isset($_POST['saveUnpublisherParams_nonce'])) {
+            return $post_id;
+        }
 
-    //     if (!wp_verify_nonce($_POST['saveUnpublisherParams_nonce'], 'saveUnpublisherParams')) {
-    //         return $post_id;
-    //     }
+        if (!wp_verify_nonce($_POST['saveUnpublisherParams_nonce'], 'saveUnpublisherParams')) {
+            return $post_id;
+        }
 
-    //     update_post_meta($post_id, '_wUnpublisher_date', $_POST['wUnpublisher_date']);
-    // }
+        update_post_meta($post_id, '_wUnpublisher_date', $_POST['wUnpublisher_date']);
+    }
 
     public function scheduleUnpublishPosts()
     {
-        // if (!wp_next_scheduled('woody_unpublish_posts')) {
-        //     wp_schedule_event(time(), 'hourly', 'woody_unpublish_posts');
-        //     output_success(sprintf('+ Schedule %s', 'woody_unpublish_posts'));
-        // }
-
-        if (wp_next_scheduled('woody_unpublish_posts')) {
-            wp_clear_scheduled_hook('woody_unpublish_posts');
+        if (!wp_next_scheduled('woody_unpublish_posts')) {
+            wp_schedule_event(time(), 'hourly', 'woody_unpublish_posts');
             output_success(sprintf('- Schedule %s', 'woody_unpublish_posts'));
         }
     }
 
-    // public function woodyUnpublishPosts()
-    // {
-    //     global $wpdb;
+    public function woodyUnpublishPosts()
+    {
+        global $wpdb;
 
-    //     $today = date(DATE_ATOM);
-    //     $results = $wpdb->get_results(
-    //         "SELECT `wp_posts`.`ID`
-    //         FROM `wp_posts`, `wp_postmeta`
-    //         WHERE `wp_posts`.`ID` = `wp_postmeta`.`post_id`
-    //         AND `wp_postmeta`.`meta_key` = '_wUnpublisher_date'
-    //         AND `wp_postmeta`.`meta_value` < {$today}
-    //         AND `wp_postmeta`.`meta_value` != ''"
-    //     );
+        // TODO: use WOODY_TIMEZONE to get the current date based on the right time zone
+        $today = date(DATE_ATOM);
 
-    //     if (!empty($results)) {
-    //         foreach ($results as $result) {
-    //             wp_update_post([
-    //                 'ID' => $result->ID,
-    //                 'post_status' => 'draft'
-    //             ]);
-    //             update_post_meta($result->ID, '_wUnpublisher_date', '');
-    //         }
-    //     }
-    // }
+        // On récupère les posts publiés qui ont une date de dépublication inférieure à la date courante
+        // TODO: use {$wpdb->prefix}
+        $results = $wpdb->get_results(
+        "SELECT wp_posts.ID
+        FROM wp_posts, wp_postmeta
+        WHERE wp_posts.ID = wp_postmeta.post_ID
+        AND wp_posts.post_status = 'publish'
+        AND wp_postmeta.meta_key = '_wUnpublisher_date'
+        AND wp_postmeta.meta_value != ''
+        AND wp_postmeta.meta_value < '{$today}'
+        ");
+
+        if (!empty($results)) {
+            foreach ($results as $result) {
+                wp_update_post([
+                    'ID' => $result->ID,
+                    'post_status' => 'draft'
+                ]);
+                update_post_meta($result->ID, '_wUnpublisher_date', '');
+                clean_post_cache($result->ID);
+            }
+        }
+    }
 }

--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -87,8 +87,11 @@ class WoodyTheme_Unpublisher
     {
         global $wpdb;
 
-        // TODO: use WOODY_TIMEZONE to get the current date based on the right time zone
-        $today = date(DATE_ATOM);
+        \Moment\Moment::setLocale('fr_FR');
+        $m = new \Moment\Moment();
+        $m->setTimezone(WOODY_TIMEZONE);
+
+        $current_date = $m->format();
 
         // On récupère les posts publiés qui ont une date de dépublication inférieure à la date courante
         $results = $wpdb->get_results(
@@ -98,7 +101,7 @@ class WoodyTheme_Unpublisher
         AND {$wpdb->prefix}posts.post_status = 'publish'
         AND {$wpdb->prefix}postmeta.meta_key = '_wUnpublisher_date'
         AND {$wpdb->prefix}postmeta.meta_value != ''
-        AND {$wpdb->prefix}postmeta.meta_value < '{$today}'
+        AND {$wpdb->prefix}postmeta.meta_value < '{$current_date}'
         ");
 
         if (!empty($results)) {

--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -17,37 +17,37 @@ class WoodyTheme_Unpublisher
 
     protected function registerHooks()
     {
-        // add_action('add_meta_boxes', array($this, 'registerMetaBox'));
+        add_action('add_meta_boxes', array($this, 'registerMetaBox'));
         // add_action('save_post', array($this, 'saveUnpublisherParams'));
 
         add_action('woody_theme_update', [$this, 'scheduleUnpublishPosts']);
         // add_action('woody_unpublish_posts', [$this, 'woodyUnpublishPosts']);
     }
 
-    // public function registerMetaBox()
-    // {
-    //     add_meta_box(
-    //         'woody-unpublisher',
-    //         'Planifier la dépublication',
-    //         array($this, 'unpublisherMetaBoxTpl'),
-    //         'page',
-    //         'side',
-    //         'high'
-    //     );
-    // }
+    public function registerMetaBox()
+    {
+        add_meta_box(
+            'woody-unpublisher',
+            'Planifier la dépublication',
+            array($this, 'unpublisherMetaBoxTpl'),
+            'page',
+            'side',
+            'high'
+        );
+    }
 
-    // public function unpublisherMetaBoxTpl($post)
-    // {
-    //     $wUnpublisher_date_value = get_post_meta($post->ID, '_wUnpublisher_date', true);
-    //     wp_nonce_field('saveUnpublisherParams', 'saveUnpublisherParams_nonce');
+    public function unpublisherMetaBoxTpl($post)
+    {
+        $wUnpublisher_date_value = get_post_meta($post->ID, '_wUnpublisher_date', true);
+        wp_nonce_field('saveUnpublisherParams', 'saveUnpublisherParams_nonce');
 
-    //     // echo '<label for="wUnpublisher_date">Date de dépublication : </label>';
-    //     echo '<div class="input-wrapper">';
-    //     echo '<input placeholder="Choisir une date" id="wUnpublisher_date" name="wUnpublisher_date" value="' . $wUnpublisher_date_value . '"/>';
-    //     echo '<small class="unpublisher-reset-date">x</small>';
-    //     echo '</div>';
-    //     echo '<div><small><i>À compter de la date choisie (+/- 1h), le contenu passe en brouillon</div></small></i>';
-    // }
+        echo '<label for="wUnpublisher_date">Date de dépublication : </label>';
+        echo '<div class="input-wrapper">';
+        echo '<input placeholder="Choisir une date" id="wUnpublisher_date" name="wUnpublisher_date" value="' . $wUnpublisher_date_value . '"/>';
+        echo '<small class="unpublisher-reset-date">x</small>';
+        echo '</div>';
+        echo '<div><small><i>À compter de la date choisie (+/- 1h), le contenu passe en brouillon</div></small></i>';
+    }
 
     // public function saveUnpublisherParams($post_id)
     // {

--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -26,11 +26,22 @@ class WoodyTheme_Unpublisher
 
     public function registerMetaBox()
     {
+        $post_types = get_post_types(['public' => true, '_builtin' => false]);
+        $post_types['page'] = 'page';
+
+        $exclude = ['short_link', 'snowflake_config', 'testimony', 'touristic_sheet', 'woody_model', 'woody_section_model'];
+
+        foreach ($post_types as $post_type) {
+            if(in_array($post_type, $exclude)) {
+                unset($post_types[$post_type]);
+            }
+        }
+
         add_meta_box(
             'woody-unpublisher',
             'Planifier la dépublication',
             array($this, 'unpublisherMetaBoxTpl'),
-            'page',
+            $post_types,
             'side',
             'high'
         );
@@ -41,7 +52,7 @@ class WoodyTheme_Unpublisher
         $wUnpublisher_date_value = get_post_meta($post->ID, '_wUnpublisher_date', true);
         wp_nonce_field('saveUnpublisherParams', 'saveUnpublisherParams_nonce');
 
-        echo '<label for="wUnpublisher_date">Date de dépublication : </label>';
+        // echo '<label for="wUnpublisher_date">Date de dépublication : </label>';
         echo '<div class="input-wrapper">';
         echo '<input placeholder="Choisir une date" id="wUnpublisher_date" name="wUnpublisher_date" value="' . $wUnpublisher_date_value . '"/>';
         echo '<small class="unpublisher-reset-date">x</small>';

--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -29,11 +29,12 @@ class WoodyTheme_Unpublisher
         $post_types = get_post_types(['public' => true, '_builtin' => false]);
         $post_types['page'] = 'page';
 
-        // TODO: add apply filters
-        $exclude = ['short_link', 'snowflake_config', 'testimony', 'touristic_sheet', 'woody_model', 'woody_section_model'];
+        $excluded = ['short_link', 'snowflake_config', 'testimony', 'touristic_sheet', 'woody_model', 'woody_section_model'];
+
+        $excluded = apply_filters('woody/unpublisher/excluded_post_types', $excluded);
 
         foreach ($post_types as $post_type) {
-            if(in_array($post_type, $exclude)) {
+            if(in_array($post_type, $excluded)) {
                 unset($post_types[$post_type]);
             }
         }

--- a/library/classes/content/class-unpublisher.php
+++ b/library/classes/content/class-unpublisher.php
@@ -90,15 +90,14 @@ class WoodyTheme_Unpublisher
         $today = date(DATE_ATOM);
 
         // On récupère les posts publiés qui ont une date de dépublication inférieure à la date courante
-        // TODO: use {$wpdb->prefix}
         $results = $wpdb->get_results(
-        "SELECT wp_posts.ID
-        FROM wp_posts, wp_postmeta
-        WHERE wp_posts.ID = wp_postmeta.post_ID
-        AND wp_posts.post_status = 'publish'
-        AND wp_postmeta.meta_key = '_wUnpublisher_date'
-        AND wp_postmeta.meta_value != ''
-        AND wp_postmeta.meta_value < '{$today}'
+        "SELECT {$wpdb->prefix}posts.ID
+        FROM {$wpdb->prefix}posts, {$wpdb->prefix}postmeta
+        WHERE {$wpdb->prefix}posts.ID = {$wpdb->prefix}postmeta.post_ID
+        AND {$wpdb->prefix}posts.post_status = 'publish'
+        AND {$wpdb->prefix}postmeta.meta_key = '_wUnpublisher_date'
+        AND {$wpdb->prefix}postmeta.meta_value != ''
+        AND {$wpdb->prefix}postmeta.meta_value < '{$today}'
         ");
 
         if (!empty($results)) {


### PR DESCRIPTION
- Ajout d'un filtre pour exclure les post types non autorisés à avoir la dépublication de posts.
- Amélioration légère de la requête SQL (syntaxe + formatage de date avec Moment pour être réglé sur la bonne timezone avec `WOODY_TIMEZONE`).

Testé sur les post types suivants :

- page
- claims
- leaflets
- profile

**Evolution qui mérite peut-être un test sur Marseille ou Vichy avant de la passer sur tous les Woody**