### PR TITLE
[0060658] add label date publi en-tête

### DIFF
--- a/acf-json/group_5b2bbb46507bf.json
+++ b/acf-json/group_5b2bbb46507bf.json
@@ -136,6 +136,31 @@
             "ui_off_text": ""
         },
         {
+            "key": "field_64073bb087b59",
+            "label": "Libellé de date",
+            "name": "page_teaser_display_label_date",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                {
+                    "field": "field_5d9209b23a9d1",
+                    "operator": "==",
+                    "value": "1"
+                }
+            ],
+            "wrapper": {
+                "width": "25",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": "",
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
             "key": "field_5fae9dfc36cb5",
             "label": "Class css",
             "name": "page_teaser_class",

--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -607,6 +607,7 @@ class WoodyTheme_WoodyCompilers
         }
 
         if (!empty($page_teaser['page_teaser_display_created'])) {
+            $page_teaser['page_teaser_display_label_date'] = !empty($page_teaser['page_teaser_display_label_date']) ? $page_teaser['page_teaser_display_label_date'] : __('Publié le', 'woody-theme');
             $page_teaser['created'] = get_the_date();
         }
 


### PR DESCRIPTION
**Changement de l'affichage de la date**
- **Nouveau champs** "Libellé de date" dans le back office **si** le champs "Date de publication est **coché**"
![image](https://user-images.githubusercontent.com/97923256/223470576-3ac2424a-750b-4b90-a635-c9109872db7b.png)

- Si le champs de texte est rempli, retourne le texte saisie, sinon retourne "Publié le + date" par défaut

Sans remplir le champs : 
![image](https://user-images.githubusercontent.com/97923256/223471202-1f0c3c7e-0850-4a7c-8917-2674d48bc96b.png)

Après avoir rempli le champs : 
![image](https://user-images.githubusercontent.com/97923256/223471017-4926a300-2670-4d56-9697-c49f270a6bac.png)

**Attention !** Cette **PR** est **liée** avec la PR sur la library (nom branch : feature/addLabelPublicationDate)
 