### PR TITLE
Bugfix/ Modification des données envoyées pour l'affichage des dates

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -686,11 +686,25 @@ class WoodyTheme_WoodyGetters
         // Parcourir tout le tableau de dates et afficher la 1ère date non passée
         if ($sheet_item['bordereau'] == 'FMA' && !empty($sheet_item['dates'])) {
             $today = time();
-            foreach ($sheet_item['dates'] as $date) {
-                $enddate= strtotime($date['end']['endDate']);
-                if ($today < $enddate) {
-                    $data['date'] = $date;
-                    break 1 ;
+
+            // On teste si il y a plusieurs dates (plusieurs jours avec des horaires différents par exemple)
+            if(count($sheet_item['dates']) > 1) {
+                $firstDate = array_shift($sheet_item['dates']); // Première date de la liste
+                $lastDate = end($sheet_item['dates']); // Dernière date de la liste
+
+                $enddate = strtotime($lastDate['end']['endDate']);
+
+                if ($today < $enddate) { // Si la dernière date n'est pas passée
+                    $data['date'] = $lastDate;
+                    $data['date']['start'] = $firstDate['start'];
+                    $data['date']['oneday'] = false;
+                }
+            } else {
+                foreach ($sheet_item['dates'] as $date) {
+                    $enddate = strtotime($date['end']['endDate']);
+                    if ($today < $enddate) {
+                        $data['date'] = $date;
+                    }
                 }
             }
         }

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -699,12 +699,10 @@ class WoodyTheme_WoodyGetters
                     $data['date']['start'] = $firstDate['start'];
                     $data['date']['oneday'] = false;
                 }
-            } else {
-                foreach ($sheet_item['dates'] as $date) {
-                    $enddate = strtotime($date['end']['endDate']);
-                    if ($today < $enddate) {
-                        $data['date'] = $date;
-                    }
+            } else { // Si il n'y a qu'une seule date
+                $enddate = strtotime($sheet_item['dates']['0']['end']['endDate']);
+                if ($today < $enddate) {
+                    $data['date'] = $sheet_item['dates']['0'];
                 }
             }
         }


### PR DESCRIPTION
Dans les cas où ils y avaient plusieurs dates avec des horaires différentes dans une fiche ([celle-ci](https://www.mulhouse-tourisme.wp.rc-prod.com/touristic_sheet/journees-doctobre-et-folie-flore-mulhouse-fr-3839592/) par exemple), seule la première date était affichée dans les mises en avant.
![image](https://user-images.githubusercontent.com/91457274/228856325-8f2d6a80-e7dd-45e5-9a77-388e970eb912.png)

Le tableau des données ressemble à ça lorsqu'il y a plusieurs dates :
![image](https://user-images.githubusercontent.com/91457274/228857094-7419d13a-da1c-423e-886a-6d0aab0c520d.png)

Est-ce que les dates sont forcément rentrées dans l'ordre et la première du tableau sera forcément la plus récente, et la dernière la plus ancienne, ou est-ce que je devrais plutôt utiliser strtotime() toutes les dates et prendre les deux extrémités ?

[Point click-up lié](https://app.clickup.com/t/860pwnd0q) (recette de Mulhouse)