### PR TITLE
[FEATURE] Modification de l'ordre de tri des pages dans le bloc de co…

### DIFF
--- a/acf-json/group_5c4f2efaccd2f.json
+++ b/acf-json/group_5c4f2efaccd2f.json
@@ -208,7 +208,15 @@
             "type": "radio",
             "instructions": "",
             "required": 0,
-            "conditional_logic": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5d80fa64e4fa4",
+                        "operator": "==",
+                        "value": "auto"
+                    }
+                ]
+            ],
             "wrapper": {
                 "width": "50",
                 "class": "",

--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -269,11 +269,13 @@ class WoodyTheme_WoodyCompilers
         if ($wrapper['semantic_view_type'] == 'manual' && !empty($wrapper['semantic_view_include'])) {
             $the_query = [
                 'post_type' => 'page',
+                'orderby' => 'post__in'
             ];
             foreach ($wrapper['semantic_view_include'] as $included_id) {
                 $the_query['post__in'][] = $included_id;
             }
-        } else {
+        }
+        else {
             $parent_id = $wrapper['semantic_view_type'] == 'sisters' ? wp_get_post_parent_id($post_id) : $post_id;
 
             if (!empty($wrapper['semantic_view_page_types'])) {


### PR DESCRIPTION
…con sémantique en manuel

Les pages s'affichaient dans l'ordre de l'ID des pages. J'ai modifié l'acf pour que le champs de tri des pages ne s'affiche que pour les sélections automatiques, et la fonction php pour que les pages s'affichent en front dans l'ordre dans lequel elles ont été définies dans le BO