### PR TITLE
[func] ajout de la possibilité d'exclure des posts d'une mise en avant automatique

### DIFF
--- a/acf-json/group_5b2788b48d04c.json
+++ b/acf-json/group_5b2788b48d04c.json
@@ -411,7 +411,7 @@
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
-                "width": "50",
+                "width": "25",
                 "class": "",
                 "id": ""
             },
@@ -438,7 +438,7 @@
                 ]
             ],
             "wrapper": {
-                "width": "50",
+                "width": "25",
                 "class": "",
                 "id": ""
             },
@@ -451,6 +451,66 @@
             "multiple": 0,
             "return_format": "object",
             "ui": 1
+        },
+        {
+            "key": "field_64a6d058750f8",
+            "label": "Exclure des pages",
+            "name": "exclude_post",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_60cc8c88f2824",
+                        "operator": "==",
+                        "value": "pages"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "25",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_64a6d2200183b",
+            "label": "Pages à Exlure",
+            "name": "excluded_posts",
+            "type": "relationship",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_64a6d058750f8",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "post_type": [
+                "page"
+            ],
+            "taxonomy": "",
+            "filters": [
+                "search"
+            ],
+            "elements": "",
+            "min": "",
+            "max": "",
+            "return_format": "id"
         },
         {
             "key": "field_643ebac43c712",
@@ -813,7 +873,7 @@
                     "label": "Identifiant de conf Touristic Maps",
                     "name": "focus_tmaps_confid",
                     "type": "clone",
-                    "wrapper":{
+                    "wrapper": {
                         "width": 40,
                         "class": "",
                         "id": ""

--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -550,11 +550,13 @@ class WoodyTheme_WoodyProcess
         // NB : si aucun choix n'a été fait, on remonte automatiquement tous les contenus de type page
         $post_type = (!empty($query_form['focused_type']) && $query_form['focused_type'] == 'documents') ? 'attachment' : 'page';
 
+        $excluded_posts = ($query_form['exclude_post'] && !empty($query_form['excluded_posts'])) ? $query_form['excluded_posts'] : [];
+
         $the_query = [
             'post_type' => $post_type,
             'posts_per_page' => (empty($query_form['focused_count'])) ? 12 : $query_form['focused_count'],
             'post_status' => (!empty($query_form['focused_type']) && $query_form['focused_type'] == 'documents') ? ['inherit', 'publish'] : 'publish',
-            'post__not_in' => array($the_post->ID),
+            'post__not_in' => !empty($excluded_posts) ? array_merge(array($the_post->ID), $excluded_posts) : array($the_post->ID),
             'order' => $order,
             'orderby' => $orderby,
             'lang' => pll_get_post_language($the_post->ID),


### PR DESCRIPTION
Ajout de la possibilité d'exclure des posts d'une mise en avant automatique (true false dans "Plus d'option")

Si le true false est activé, en champs de relation apparaît pour sélectionner les posts à exclure. Les id sont récupéré et ajouté à l'option "post__not_in" de le wp_query (class-woody-process.php)