### PR TITLE
[bugfix] add placeholder and rm instruction stay pages

### DIFF
--- a/acf-json/group_5b6c5e6ff381d.json
+++ b/acf-json/group_5b6c5e6ff381d.json
@@ -243,7 +243,7 @@
                     "label": "Précision",
                     "name": "suffix_price",
                     "type": "text",
-                    "instructions": "<small>Si laissé vide, valeur par défaut : \"par personne\" ou \"forfait groupe\" en fonction du type de prix<\/small>",
+                    "instructions": "",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -252,7 +252,7 @@
                         "id": ""
                     },
                     "default_value": "",
-                    "placeholder": "",
+                    "placeholder": "Ex : Par personne, Par groupe, Forfait groupe, ...",
                     "prepend": "",
                     "append": "",
                     "maxlength": ""


### PR DESCRIPTION
[Suite au ticket](https://mantis.raccourci.fr/view.php?id=63543) d'Arcachon.

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/e12623f9-5485-48d1-adde-bb45dc858d79)
si le champs n'est pas rempli, rien ne s'affiche par défaut.

Modifications : 
- Suppression de l'instruction
- Ajout d'un placeholder

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/d7dfb805-d09e-49ac-ba0b-15e99b41d221)

Sera affiché, seulement ce qui est rentré par le client, donc si le champs est vide, rien ne s'affichera