### PR TITLE
Bugfix getSectionBannerFiles

### DIFF
--- a/library/classes/process/class-woody-process-tools.php
+++ b/library/classes/process/class-woody-process-tools.php
@@ -342,17 +342,21 @@ class WoodyTheme_WoodyProcessTools
      */
     public function getSectionBannerFiles($filename)
     {
-        $lang = pll_current_language();
+        if(is_string($filename)) {
 
-        if (file_exists(get_stylesheet_directory() . '/views/section_banner/'. $lang .'/section_' . $filename . '.twig')) {
-            $file = file_exists(get_stylesheet_directory() . '/views/section_banner/'. $lang .'/section_' . $filename . '.twig');
-        } elseif (file_exists(get_stylesheet_directory() . '/views/section_banner/section_' . $filename . '.twig')) {
-            $file = file_get_contents(get_stylesheet_directory() . '/views/section_banner/section_' . $filename . '.twig');
-        } else {
-            $file = file_get_contents(get_template_directory() . '/views/section_banner/section_' . $filename . '.twig');
+            $lang = pll_current_language();
+            $banner_paths = [
+                get_stylesheet_directory() . '/views/section_banner/'. $lang .'/section_' . $filename . '.twig',
+                get_stylesheet_directory() . '/views/section_banner/section_' . $filename . '.twig',
+                get_template_directory() . '/views/section_banner/section_' . $filename . '.twig',
+            ];
+
+            foreach ($banner_paths as $path) {
+                if (file_exists($path)) {
+                    return file_get_contents($path);
+                }
+            }
         }
-
-        return $file;
     }
 
     /**


### PR DESCRIPTION
Je pense que mon correctif va régler ce type d'erreur dans NewRelic mais je veux bien un contrôle de votre part. Merci 

E_WARNING
file_get_contents(/home/admin/www/wordpress/current/web/app/themes/woody-theme/views/section_banner/section_a:2:{i:0;s:10:&quot;banner_top&quot;;i:1;s:13:&quot;banner_bottom&quot;;}.twig): failed to open stream: No such file or directory