### PR TITLE
Feature/add sheet aspect on search

### DIFF
--- a/acf-json/group_5c0fed3541b45.json
+++ b/acf-json/group_5c0fed3541b45.json
@@ -95,6 +95,25 @@
             "ui_off_text": ""
         },
         {
+            "key": "field_64f9cb7966f5c",
+            "label": "Afficher l'aspect des fiches dans les champs de recherche",
+            "name": "display_sheet_aspect",
+            "type": "true_false",
+            "instructions": "Si cette option est activée, l'aspect de la fiche sera affiché à la suite du titre",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
             "key": "field_611f6f55bc6de",
             "label": "Page des bons plans",
             "name": "",

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -553,15 +553,13 @@ class WoodyTheme_ACF
     }
 
     public function translatePostTitleResult($title, $post, $field, $post_id) {
-        if ($display_default_lang_title) {
-            $post_lang = apply_filters('woody_pll_get_post_language', $post->ID);
-            $default_lang = apply_filters('woody_pll_default_lang_code', null);
+        $post_lang = apply_filters('woody_pll_get_post_language', $post->ID);
+        $default_lang = apply_filters('woody_pll_default_lang_code', null);
 
-            if ($post_lang !== $default_lang) {
-                $translation = apply_filters('woody_default_lang_post_title', $post->ID);
-                if (!empty($translation)) {
-                    $title = $title . '<small style="color:#cfcfcf; font-style:italic"> - ( ' . $default_lang . ': ' . $translation . ' )</small>';
-                }
+        if ($post_lang !== $default_lang) {
+            $translation = apply_filters('woody_default_lang_post_title', $post->ID);
+            if (!empty($translation)) {
+                $title = $title . '<small style="color:#cfcfcf; font-style:italic"> - ( ' . $default_lang . ': ' . $translation . ' )</small>';
             }
         }
 
@@ -569,12 +567,10 @@ class WoodyTheme_ACF
     }
 
     public function getAspectPostTitleResult($title, $post, $field, $post_id) {
-        if ($display_sheet_aspect) {
-            if ($post->post_type == 'touristic_sheet') {
-                $meta_value = get_post_meta($post->ID)['touristic_source_identifier'];
-                $sheet_lang = explode('-', $meta_value[0])[0];
-                $title = $title . '<small style="color:#cfcfcf; font-style:italic">' . $sheet_lang . '</small>';
-            }
+        if ($post->post_type == 'touristic_sheet') {
+            $meta_value = get_post_meta($post->ID)['touristic_source_identifier'];
+            $sheet_lang = explode('-', $meta_value[0])[0];
+            $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_lang . '</small>';
         }
 
         return $title;

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -571,8 +571,11 @@ class WoodyTheme_ACF
             $touristic_source_identifier = get_field('touristic_source_identifier', $post->ID);
 
             if (!empty($touristic_source_identifier)) {
-                $sheet_aspect = explode('-', $touristic_source_identifier)[0];
-                $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_aspect . '</small>';
+                $sheet_aspect = sizeof(explode('-', $touristic_source_identifier)) > 1 ? explode('-', $touristic_source_identifier)[0] : null;
+
+                if (!empty($sheet_aspect)) {
+                    $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_aspect . '</small>';
+                }
             }
         }
 

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -568,10 +568,10 @@ class WoodyTheme_ACF
 
     public function getAspectPostTitleResult($title, $post, $field, $post_id) {
         if ($post->post_type == 'touristic_sheet') {
-            $meta_value = get_field('touristic_source_identifier', $post->ID);
+            $touristic_source_identifier = get_field('touristic_source_identifier', $post->ID);
 
-            if (!empty($meta_value)) {
-                $sheet_aspect = explode('-', $meta_value)[0];
+            if (!empty($touristic_source_identifier)) {
+                $sheet_aspect = explode('-', $touristic_source_identifier)[0];
                 $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_aspect . '</small>';
             }
         }

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -62,6 +62,16 @@ class WoodyTheme_ACF
         add_filter('acf/fields/post_object/query', [$this, 'getPostObjectDefaultTranslation'], 10, 3);
         add_filter('acf/fields/page_link/result', [$this, 'postObjectAcfResults'], 10, 4);
 
+        if (get_field('display_default_lang_title', 'options')) {
+            add_filter('acf/fields/post_object/result', [$this, 'translatePostTitleResult'], 10, 4);
+            add_filter('acf/fields/page_link/result', [$this, 'translatePostTitleResult'], 10, 4);
+        }
+
+        if (get_field('display_sheet_aspect', 'options')) {
+            add_filter('acf/fields/post_object/result', [$this, 'getAspectPostTitleResult'], 10, 4);
+            add_filter('acf/fields/page_link/result', [$this, 'getAspectPostTitleResult'], 10, 4);
+        }
+
         add_filter('acf/load_value/type=gallery', [$this, 'pllGalleryLoadField'], 10, 3);
 
         add_filter('acf/load_field/name=section_content', [$this, 'sectionContentLoadField']);
@@ -534,7 +544,15 @@ class WoodyTheme_ACF
     {
         $parent_id = getPostRootAncestor($post->ID);
 
-        $display_default_lang_title = apply_filters('woody_get_field_option', 'display_default_lang_title');
+        if (!empty($parent_id)) {
+            $parent = get_post($parent_id);
+            $title = $title . '<small style="color:#cfcfcf; font-style:italic"> - ( Enfant de ' . $parent->post_title . ' )</small>';
+        }
+
+        return $title;
+    }
+
+    public function translatePostTitleResult($title, $post, $field, $post_id) {
         if ($display_default_lang_title) {
             $post_lang = apply_filters('woody_pll_get_post_language', $post->ID);
             $default_lang = apply_filters('woody_pll_default_lang_code', null);
@@ -547,9 +565,16 @@ class WoodyTheme_ACF
             }
         }
 
-        if (!empty($parent_id)) {
-            $parent = get_post($parent_id);
-            $title = $title . '<small style="color:#cfcfcf; font-style:italic"> - ( Enfant de ' . $parent->post_title . ' )</small>';
+        return $title;
+    }
+
+    public function getAspectPostTitleResult($title, $post, $field, $post_id) {
+        if ($display_sheet_aspect) {
+            if ($post->post_type == 'touristic_sheet') {
+                $meta_value = get_post_meta($post->ID)['touristic_source_identifier'];
+                $sheet_lang = explode('-', $meta_value[0])[0];
+                $title = $title . '<small style="color:#cfcfcf; font-style:italic">' . $sheet_lang . '</small>';
+            }
         }
 
         return $title;

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -568,9 +568,12 @@ class WoodyTheme_ACF
 
     public function getAspectPostTitleResult($title, $post, $field, $post_id) {
         if ($post->post_type == 'touristic_sheet') {
-            $meta_value = get_post_meta($post->ID)['touristic_source_identifier'];
-            $sheet_lang = explode('-', $meta_value[0])[0];
-            $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_lang . '</small>';
+            $meta_value = get_field('touristic_source_identifier', $post->ID);
+
+            if (!empty($meta_value)) {
+                $sheet_aspect = explode('-', $meta_value)[0];
+                $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_aspect . '</small>';
+            }
         }
 
         return $title;

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -571,7 +571,8 @@ class WoodyTheme_ACF
             $touristic_source_identifier = get_field('touristic_source_identifier', $post->ID);
 
             if (!empty($touristic_source_identifier)) {
-                $sheet_aspect = sizeof(explode('-', $touristic_source_identifier)) > 1 ? explode('-', $touristic_source_identifier)[0] : null;
+                $get_aspect = explode('-', $touristic_source_identifier);
+                $sheet_aspect = sizeof($get_aspect) > 1 ? $get_aspect[0] : null;
 
                 if (!empty($sheet_aspect)) {
                     $title = $title . '<small style="color:#cfcfcf; font-style:italic; text-transform: uppercase"> - ' . $sheet_aspect . '</small>';


### PR DESCRIPTION
Lorsqu'on recherche un page dans un bloc (ex : MEA manuelle), on ne peut pas différencier les fiches ayant le même nom mais un aspect différent.

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/7df3b277-4b88-446b-8752-d46d03403741)

Un paramètre a été ajouter dans les paramètres généraux permettant d'afficher l'aspect des fiches lors de cette recherche

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/f9c23dd2-70e9-47ad-a399-f2e435d53025)

L'aspect s'affiche alors à la suite du titre (comme c'est le cas pour l'affichage de la page parente ou la traduction du titre)

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/49886642-e695-428a-a1a6-b5fa5509364c)

Cette modification a été branché sur deux filtres : 
- acf/fields/post_object/result
- acf/fields/page_link/result