### PR TITLE
ajout de la possibilité de mettre des documents dans les listes de contenus

### DIFF
--- a/acf-json/group_5bc6005838259.json
+++ b/acf-json/group_5bc6005838259.json
@@ -94,7 +94,7 @@
                 "class": "",
                 "id": ""
             },
-            "default_value": "blocks-focus-tpl_103",
+            "default_value": "lists-list_grids-tpl_207",
             "placeholder": "",
             "prepend": "",
             "append": "",

--- a/acf-json/group_5bc6005838259.json
+++ b/acf-json/group_5bc6005838259.json
@@ -1,7 +1,8 @@
 {
     "key": "group_5bc6005838259",
     "title": "Elements de liste",
-    "fields": [{
+    "fields": [
+        {
             "key": "field_5bc60342c66b8",
             "label": "Contenu",
             "name": "",
@@ -31,14 +32,15 @@
                 "id": ""
             },
             "clone": [
+                "field_60cc8c88f2824",
+                "field_60cc8e1147740",
                 "field_5b27890c84ed3",
                 "field_5b27a02e9d7c5",
                 "field_5b27a25103e43",
                 "field_5b28d791038fa",
-                "field_5b27a67203e48",
                 "field_5b27a3d703e44",
+                "field_5b27a67203e48",
                 "field_5b2917f0ff061",
-                "field_5c814940fba28",
                 "field_5b88eae6c0adc"
             ],
             "display": "group",
@@ -153,11 +155,13 @@
         }
     ],
     "location": [
-        [{
-            "param": "post_type",
-            "operator": "==",
-            "value": "post"
-        }]
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
     ],
     "menu_order": 0,
     "position": "normal",


### PR DESCRIPTION
Dans les listes de contenu on ne peut mettre que des pages. 

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/7e5812ce-7c38-4d5d-b27e-bb56a5673a30)

On peut maintenant mettre des documents au format pdf comme c'est le cas pour les MEA automatique

![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/974088c2-f4df-408d-bb0a-5aaf2aedf5c5)

Exemple de rendu sur les saisies
![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/d765f822-d213-4a67-92a3-a806b3b6018e)


Ce bloc n'a que des templates grille, or la valeur par défaut était un slider (tpl 103), j'ai mis le tpl de grille 207 par défaut)

