### PR TITLE
Feature/term cache

### DIFF
--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -29,6 +29,8 @@ class WoodyTheme_ACF
         add_action('create_term', [$this, 'cleanTermsChoicesCache']);
         add_action('edit_term', [$this, 'cleanTermsChoicesCache']);
         add_action('delete_term', [$this, 'cleanTermsChoicesCache']);
+        // Suppression du cache des blocs pour mettre à jour les termes des taxonomies
+        add_action('saved_term', [$this, 'deleteTermCache'], 10, 4);
 
         add_action('acf/init', [$this, 'registerHooksAfterAcfInit']);
 
@@ -1091,6 +1093,32 @@ class WoodyTheme_ACF
 
         remove_filter('user_can_richedit', [$this, 'addUserRichedit']);
         $user->remove_cap('upload_files');
+    }
+
+    public function deleteTermCache($term_id, $tt_id, $taxonomy, $update) {
+        switch($taxonomy) {
+            case 'seasons':
+            case 'attachment_categorie':
+            case 'themes':
+            case 'places':
+                wp_cache_delete('layout-auto_focus');
+                wp_cache_delete('layout-manual_focus');
+                wp_cache_delete('layout-content_list');
+                wp_cache_delete('layout-gallery');
+                break;
+            case 'attachment_hashtags':
+                wp_cache_delete('layout-socialwall');
+                break;
+            default:
+                break;
+        }
+
+        // $field = acf_get_field("field_5b043f0525968");
+
+        // foreach ($field['layouts'] as $layout) {
+        //     console_log($layout['name']);
+        //     // wp_cache_delete('layout-' . $layout['name']);
+        // }
     }
 
     public function addUserRichedit()

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -1112,13 +1112,6 @@ class WoodyTheme_ACF
             default:
                 break;
         }
-
-        // $field = acf_get_field("field_5b043f0525968");
-
-        // foreach ($field['layouts'] as $layout) {
-        //     console_log($layout['name']);
-        //     // wp_cache_delete('layout-' . $layout['name']);
-        // }
     }
 
     public function addUserRichedit()

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -1102,7 +1102,6 @@ class WoodyTheme_ACF
             case 'themes':
             case 'places':
                 wp_cache_delete('layout-auto_focus');
-                wp_cache_delete('layout-manual_focus');
                 wp_cache_delete('layout-content_list');
                 wp_cache_delete('layout-gallery');
                 break;


### PR DESCRIPTION
Lorsqu'on ajout un bloc dans une page de Bo on met le DOM généré en cache. Si on rajoute un tags (ex : une categorie de media), lorsqu'on va rajouter un bloc on va récupérer le DOM en cache et le tag ne s'affichera pas.

Maintenant, une fonction branchée sur le hook saved_term va permettre d'unset le cache de certains blocs pour quà leur prochain ajout, on mette en cache la nouvelle version du DOM

**Taxonomie concernée :** 
- Saisons
- Catégories de media
- Thématiques
- Lieux
- Hashtags

**Blocs concernés :**
- MEA auto
- Liste de contenus
- Gallerie de médias
- socialwall (seulement pour les hashtags)