### PR TITLE
Feature/error on required field

### DIFF
--- a/src/js/admin/edit-post-save-ajax.js
+++ b/src/js/admin/edit-post-save-ajax.js
@@ -53,18 +53,22 @@ const savePost = (e, publish) => {
 
     e.preventDefault();
 
-    if (!isValid) {
-        const fieldErrorNotices = document.querySelectorAll('.acf-notice.acf-error-message');
-        if (fieldErrorNotices.length > 0) {
-            fieldErrorNotices.forEach(errorNotice => errorNotice.remove());
-        }
+    // Si une erreur est déjà affichée on l'enève
+    const fieldErrorNotices = document.querySelectorAll('.acf-notice.acf-error-message');
+    if (fieldErrorNotices.length > 0) {
+        fieldErrorNotices.forEach(errorNotice => errorNotice.remove());
+    }
 
+    // Si un champs obligatoire n'a pas été rempli
+    if (!isValid) {
+        // Arrêt du spinner
         if (spinner) spinner.classList.remove('is-active');
-        // notice d'erreur
+        // Ajout de la notice d'erreur en haut de l'écran
         createNotice('notice-error', `Impossible d\'enregistrer la page, un champ obligatoire nécessite votre attention.`);
         invalidFieldNotice(invalidField);
 
-        // uncollapse bloc
+        // Ouverture des éléments pour repérer facilement l'erreur
+        // Bloc
         while (invalidField !== null && !invalidField.classList.contains('acf-row')) {
             if (invalidField.classList.contains('layout')) {
                 invalidField.classList.remove('-collapsed');
@@ -73,7 +77,7 @@ const savePost = (e, publish) => {
             invalidField = invalidField.parentElement;
         }
 
-        // uncollaspe section
+        // Section
         if (invalidField.classList.contains('-collapsed')) {
             invalidField.classList.remove('-collapsed');
         }

--- a/src/js/admin/edit-post-save-ajax.js
+++ b/src/js/admin/edit-post-save-ajax.js
@@ -88,7 +88,20 @@ const savePost = (e, publish) => {
                             case 'select':
                                 if (field.querySelectorAll('.acf-selection').length == 0) {
                                     invalidField(field);
-                                    console.log(field);
+
+                                    // uncollapse bloc
+                                    while (field !== null && !field.classList.contains('acf-row')) {
+                                        if (field.classList.contains('layout')) {
+                                            field.classList.remove('-collapsed');
+                                        }
+
+                                        field = field.parentElement;
+                                    }
+
+                                    // uncollaspe section
+                                    if (field.classList.contains('-collapsed')) {
+                                        field.classList.remove('-collapsed');
+                                    }
                                 }
                                 break;
                             case 'text':


### PR DESCRIPTION
Lorsqu'un champs obligatoire n'est pas rempli, le fetch retourne un code 200 alors que l'enregistrement des champs n'a pas réellement était fait.

Exemple : Dans le bloc de pub, si on ne sélectionne pas d'emplacement et qu'on enregistre, les données vont se sauvegarder mais le rendu en front ne fonctionnera pas car un champs obligatoire n'a pas été rempli.

Modifications : 
- Au clic sur "Publier" ou "Mettre à jour", on va récupérer les champs obligatoire et vérifier si la valeur du select (type taxonomie/select) ou de l'input (champs type text) on été rempli. Si on tombe sur un champs non rempli, on arrête le traitement, on affiche un bandeau d'erreur et on ouvre le bloc et la section concerné pour localiser facilement l'erreur AVANT LE FETCH
- Si aucune erreur n'est trouvée, on effectue le fetch

Avant
![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/d1b3321f-8b85-4aab-adc8-5606126ae790)

Après 
![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/edd7f5bd-25e3-423d-8996-1ba5f9e204ea)
