### PR TITLE
Add filter content list

### DIFF
--- a/acf-json/group_5bc6079fe9b0a.json
+++ b/acf-json/group_5bc6079fe9b0a.json
@@ -1,7 +1,8 @@
 {
     "key": "group_5bc6079fe9b0a",
     "title": "Filtres de liste",
-    "fields": [{
+    "fields": [
+        {
             "key": "field_5bc607f02a89c",
             "label": "Contenu",
             "name": "",
@@ -35,7 +36,8 @@
             "max": 0,
             "layout": "block",
             "button_label": "Ajouter un filtre",
-            "sub_fields": [{
+            "sub_fields": [
+                {
                     "key": "field_5bc85c363dc30",
                     "label": "Nom du filtre",
                     "name": "list_filter_name",
@@ -73,7 +75,8 @@
                         "price": "Prix séjour",
                         "duration": "Durée séjour",
                         "map": "Carte",
-                        "created": "Date de publication"
+                        "created": "Date de publication",
+                        "keyword": "Mots clés"
                     },
                     "default_value": [
                         "taxonomy"
@@ -93,11 +96,13 @@
                     "instructions": "",
                     "required": 0,
                     "conditional_logic": [
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "taxonomy"
-                        }]
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "taxonomy"
+                            }
+                        ]
                     ],
                     "wrapper": {
                         "width": "",
@@ -128,11 +133,13 @@
                     "instructions": "",
                     "required": 0,
                     "conditional_logic": [
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "created"
-                        }]
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "created"
+                            }
+                        ]
                     ],
                     "wrapper": {
                         "width": "",
@@ -140,9 +147,9 @@
                         "id": ""
                     },
                     "choices": {
-                        "daterange" : "Contenus publiés entre 2 dates",
-                        "from_single" : "Contenu publiés après la date",
-                        "to_single" : "Contenus publiés avant la date"
+                        "daterange": "Contenus publiés entre 2 dates",
+                        "from_single": "Contenu publiés après la date",
+                        "to_single": "Contenus publiés avant la date"
                     },
                     "allow_null": 0,
                     "other_choice": 0,
@@ -159,11 +166,13 @@
                     "instructions": "",
                     "required": 0,
                     "conditional_logic": [
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "custom_terms"
-                        }]
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "custom_terms"
+                            }
+                        ]
                     ],
                     "wrapper": {
                         "width": "",
@@ -187,16 +196,20 @@
                     "instructions": "(Comportement lorsque l'utilisateur coche plusieurs tags)",
                     "required": 0,
                     "conditional_logic": [
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "taxonomy"
-                        }],
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "custom_terms"
-                        }]
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "taxonomy"
+                            }
+                        ],
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "custom_terms"
+                            }
+                        ]
                     ],
                     "wrapper": {
                         "width": "",
@@ -222,11 +235,13 @@
                     "instructions": "",
                     "required": 0,
                     "conditional_logic": [
-                        [{
-                            "field": "field_5bc607c62a89b",
-                            "operator": "==",
-                            "value": "map"
-                        }]
+                        [
+                            {
+                                "field": "field_5bc607c62a89b",
+                                "operator": "==",
+                                "value": "map"
+                            }
+                        ]
                     ],
                     "wrapper": {
                         "width": "",
@@ -234,7 +249,8 @@
                         "id": ""
                     },
                     "layout": "block",
-                    "sub_fields": [{
+                    "sub_fields": [
+                        {
                             "key": "field_5be167b1ca075",
                             "label": "Hauteur de la carte",
                             "name": "map_zoom",
@@ -311,7 +327,7 @@
                                 "field_5c989085888ee"
                             ],
                             "new_lines": "wpautop",
-                            "display"  : "seamless"
+                            "display": "seamless"
                         },
                         {
                             "key": "field_5bl1j7f9cd075",
@@ -346,25 +362,27 @@
                 "id": ""
             },
             "layout": "block",
-            "sub_fields": [{
-                "key": "field_5bd871bd4bace",
-                "label": "Texte",
-                "name": "filter_button_text",
-                "type": "text",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "50",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "Rechercher",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            }]
+            "sub_fields": [
+                {
+                    "key": "field_5bd871bd4bace",
+                    "label": "Texte",
+                    "name": "filter_button_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "50",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "Rechercher",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
         },
         {
             "key": "field_5c0935b0aba59",
@@ -513,11 +531,13 @@
         }
     ],
     "location": [
-        [{
-            "param": "post_type",
-            "operator": "==",
-            "value": "post"
-        }]
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
     ],
     "menu_order": 0,
     "position": "normal",

--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -401,6 +401,9 @@ class WoodyTheme_WoodyCompilers
             // On surcharge le seed avec celui reçu dans les paramètres GET pour maitriser le random des listes
             $list_el_wrapper['seed'] = (empty($form_result['seed'])) ? null : $form_result['seed'];
 
+            // On surcharge les keywords reçus dans les paramètres GET
+            $list_el_wrapper[$form_result['uniqid'].'_keywords'] = (empty($form_result[$form_result['uniqid'].'_keywords'])) ? null : $form_result[$form_result['uniqid'].'_keywords'];
+
             foreach ($form_result as $result_key => $input_value) {
                 if (strpos($result_key, (string) $the_list['uniqid']) !== false && strpos($result_key, 'tt') !== false) { // Taxonomy Terms
                     $input_value = (is_array($input_value)) ? $input_value : [$input_value];

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -910,6 +910,10 @@ class WoodyTheme_WoodyGetters
 
                         $return[$key]['filter_name'] = $filter['list_filter_name'];
                         break;
+                    case 'keyword':
+                        console_log($filter, 'php debug');
+                        $return[$key]['filter_name'] = $filter['list_filter_name'];
+                        break;
                 }
             }
 

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -911,8 +911,8 @@ class WoodyTheme_WoodyGetters
                         $return[$key]['filter_name'] = $filter['list_filter_name'];
                         break;
                     case 'keyword':
-                        console_log($filter, 'php debug');
                         $return[$key]['filter_name'] = $filter['list_filter_name'];
+                        $return[$key]['filter_type'] = $filter['list_filter_type'];
                         break;
                 }
             }

--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -562,6 +562,10 @@ class WoodyTheme_WoodyProcess
             'lang' => pll_get_post_language($the_post->ID),
         ];
 
+        if (!empty($query_form[$uniqid.'_keywords'])) {
+            $the_query['s'] = $query_form[$uniqid.'_keywords'];
+        }
+
         if (!empty($posts_in)) {
             $the_query['post__in'] = $posts_in;
         }


### PR DESCRIPTION
Ajout d'un filtre de recherche par mots clés dans le bloc de liste de contenu. La recherche s'effectue uniquement dans le titre des posts (pages et documents)

/!\ : lié avec la [PR suivante](https://git.rc-prod.com/raccourci/woody-wordpress/addons/woody-library/-/merge_requests/769) sur la librairie