### PR TITLE
Feature/update page preview api

### DIFF
--- a/library/classes/content/class-api-rest.php
+++ b/library/classes/content/class-api-rest.php
@@ -36,7 +36,17 @@ class WoodyTheme_Api_Rest
         $display = filter_input(INPUT_GET, 'display');
 
         $display_decoded = json_decode(base64_decode($display), true);
-        $wrapper = empty($display_decoded) ? ['display_img' => true, 'display_button' => false] : $display_decoded;
+
+        if (empty($display_decoded)) {
+            $wrapper = ['display_img' => true, 'display_button' => false];
+        } else if (!empty($display_decoded) && empty($ratio)) {
+            $display_decoded['display_img'] = false;
+            $wrapper = $display_decoded;
+        } else {
+            $display_decoded['display_img'] = true;
+            $wrapper = $display_decoded;
+        }
+
         $post_preview = [];
 
         // Cas d'une mise en avant contenu existant

--- a/library/classes/content/class-api-rest.php
+++ b/library/classes/content/class-api-rest.php
@@ -24,12 +24,15 @@ class WoodyTheme_Api_Rest
         });
     }
 
-    public function getPagePreviewApiRest() {
-
-        # /wp-json/woody/page/preview?post=${id}&field=${field}&current_id=${current_id}
+    public function getPagePreviewApiRest()
+    {
+        # /wp-json/woody/page/preview?post=${id}&field=${field}&current_id=${current_id}&html_format=${html_format}&tpl_twig=${tpl_twig}&ratio=${ratio}
         $post_id = filter_input(INPUT_GET, 'post', FILTER_VALIDATE_INT);
         $field = filter_input(INPUT_GET, 'field');
         $current_id = filter_input(INPUT_GET, 'current_id', FILTER_VALIDATE_INT);
+        $html_format = filter_input(INPUT_GET, 'html_format', FILTER_VALIDATE_BOOLEAN);
+        $tpl_twig = filter_input(INPUT_GET, 'tpl_twig');
+        $ratio = filter_input(INPUT_GET, 'ratio');
 
         $wrapper = [
             'display_img' => true,
@@ -62,17 +65,23 @@ class WoodyTheme_Api_Rest
                 }
             }
 
-            return $post_preview;
         // Cas d'une mise en avant contenu libre
         } elseif(!empty($field) && !empty($current_id)) {
             // On récupère le contenu de l'item par rapport à son index de section, son index de bloc et son post id
             $item = get_field($field, $current_id);
 
             $post_preview = empty($item) ? '' : getCustomPreview($item, $wrapper);
-
-            return $post_preview;
         } else {
             return 'getPagePreviewApiRest : erreur dans les paramètres';
+        }
+
+        if ($html_format == true && !empty($tpl_twig)) {
+            return Timber::compile('cards/' . $tpl_twig . '/tpl.twig', [
+                'item' => $post_preview,
+                'image_style' => $ratio
+            ]);
+        } else {
+            return $post_preview;
         }
     }
 }

--- a/library/classes/content/class-api-rest.php
+++ b/library/classes/content/class-api-rest.php
@@ -36,15 +36,8 @@ class WoodyTheme_Api_Rest
         $display = filter_input(INPUT_GET, 'display');
 
         $display_decoded = json_decode(base64_decode($display), true);
-
-        if (empty($display_decoded)) {
-            $wrapper = [
-                'display_img' => true,
-                'display_button' => false
-            ];
-        } else {
-            $wrapper = $display_decoded;
-        }
+        $wrapper = empty($display_decoded) ? ['display_img' => true, 'display_button' => false] : $display_decoded;
+        $post_preview = [];
 
         // Cas d'une mise en avant contenu existant
         if(!empty($post_id)) {
@@ -52,8 +45,6 @@ class WoodyTheme_Api_Rest
             $post = get_post($post_id);
 
             if ($post->post_status == 'publish') {
-                $post_preview = [];
-
                 switch ($post->post_type) {
                     case 'touristic_sheet':
                         $post_preview = getTouristicSheetPreview($wrapper, $post);
@@ -69,12 +60,12 @@ class WoodyTheme_Api_Rest
             // On récupère le contenu de l'item par rapport à son index de section, son index de bloc et son post id
             $item = get_field($field, $current_id);
 
-            $post_preview = empty($item) ? '' : getCustomPreview($item, $wrapper);
+            $post_preview = empty($item) ? [] : getCustomPreview($item, $wrapper);
         } else {
             return 'getPagePreviewApiRest : erreur dans les paramètres';
         }
 
-        if ($html_format == true && !empty($tpl_twig)) {
+        if ($html_format && !empty($tpl_twig)) {
             return Timber::compile('cards/' . $tpl_twig . '/tpl.twig', [
                 'item' => $post_preview,
                 'image_style' => $ratio

--- a/library/classes/content/class-api-rest.php
+++ b/library/classes/content/class-api-rest.php
@@ -26,26 +26,25 @@ class WoodyTheme_Api_Rest
 
     public function getPagePreviewApiRest()
     {
-        # /wp-json/woody/page/preview?post=${id}&field=${field}&current_id=${current_id}&html_format=${html_format}&tpl_twig=${tpl_twig}&ratio=${ratio}
+        # /wp-json/woody/page/preview?post=${id}&field=${field}&current_id=${current_id}&html_format=${html_format}&tpl_twig=${tpl_twig}&ratio=${ratio}&display=${display}
         $post_id = filter_input(INPUT_GET, 'post', FILTER_VALIDATE_INT);
         $field = filter_input(INPUT_GET, 'field');
         $current_id = filter_input(INPUT_GET, 'current_id', FILTER_VALIDATE_INT);
         $html_format = filter_input(INPUT_GET, 'html_format', FILTER_VALIDATE_BOOLEAN);
         $tpl_twig = filter_input(INPUT_GET, 'tpl_twig');
         $ratio = filter_input(INPUT_GET, 'ratio');
+        $display = filter_input(INPUT_GET, 'display');
 
-        $wrapper = [
-            'display_img' => true,
-            'display_elements' => [
-                'icon',
-                'pretitle',
-                'subtitle',
-                'description',
-                'sheet_type',
-                'sheet_town'
-            ],
-            'display_button' => true
-        ];
+        $display_decoded = json_decode(base64_decode($display), true);
+
+        if (empty($display_decoded)) {
+            $wrapper = [
+                'display_img' => true,
+                'display_button' => false
+            ];
+        } else {
+            $wrapper = $display_decoded;
+        }
 
         // Cas d'une mise en avant contenu existant
         if(!empty($post_id)) {

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -515,6 +515,8 @@ class WoodyTheme_WoodyGetters
             }
         }
 
+        $data['cardDisplayOptions'] = $wrapper;
+
         return apply_filters('woody_custom_pagePreview', $data, $wrapper);
     }
 

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -515,7 +515,7 @@ class WoodyTheme_WoodyGetters
             }
         }
 
-        $data['cardDisplayOptions'] = $wrapper;
+        $data['cardDisplayOptions'] = $wrapper['display_elements'];
 
         return apply_filters('woody_custom_pagePreview', $data, $wrapper);
     }
@@ -610,7 +610,7 @@ class WoodyTheme_WoodyGetters
             $data['movie'] = $item['movie'];
         }
 
-        $data['cardDisplayOptions'] = $wrapper;
+        $data['cardDisplayOptions'] = $wrapper['display_elements'];
 
         return $data;
     }
@@ -758,7 +758,7 @@ class WoodyTheme_WoodyGetters
             }
         }
 
-        $data['cardDisplayOptions'] = $wrapper;
+        $data['cardDisplayOptions'] = $wrapper['display_elements'];
 
         return apply_filters('woody_custom_sheetPreview', $data, $wrapper, $post, $sheet_item);
     }

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -610,6 +610,8 @@ class WoodyTheme_WoodyGetters
             $data['movie'] = $item['movie'];
         }
 
+        $data['cardDisplayOptions'] = $wrapper;
+
         return $data;
     }
 
@@ -755,6 +757,8 @@ class WoodyTheme_WoodyGetters
                 }
             }
         }
+
+        $data['cardDisplayOptions'] = $wrapper;
 
         return apply_filters('woody_custom_sheetPreview', $data, $wrapper, $post, $sheet_item);
     }


### PR DESCRIPTION
Mise à jour de l'endpoint.

On peut désormais choisir de retourner le DOM html compiler avec un template twig, un ratio d'image et des éléments spécifiques d'affichages (icone, surtitre, sous-titre,...)

Si le paramètre html_format est à true, alors on va compiler la card avec le template, le ratio d'image et les éléments précisés.

Réduction des éléments minimum à afficher

/!\ [LIEE AVEC LA MR SUR LA LIBRARIE](https://git.rc-prod.com/raccourci/woody-wordpress/addons/woody-library/-/merge_requests/771)