### PR TITLE
[FEATURE] Ajout de la possibilité de modifier le lien de la home

### DIFF
--- a/library/templates/template.php
+++ b/library/templates/template.php
@@ -715,7 +715,7 @@ abstract class WoodyTheme_TemplateAbstract
                 $this->context['website_logo'] = $SubWoodyTheme_TemplateParts->website_logo;
             }
 
-            $this->context['home_url'] = pll_home_url();
+            $this->context['home_url'] = ($SubWoodyTheme_TemplateParts->home_url) ? $SubWoodyTheme_TemplateParts->home_url : pll_home_url();
             $this->context['page_parts'] = $SubWoodyTheme_TemplateParts->getParts();
         }
     }


### PR DESCRIPTION
[Ticket 0066017](https://mantis.raccourci.fr/view.php?id=66017)

Le header mobile récupérait toujours `pll_home_url()`. Ca posait soucis sur les sites avec des espaces différents, par exemple Saint-Gervais; qui a une home tourisme et une home mairie.