### PR TITLE
[fix] str_replace sur le crop des img venant api.cloudly.space

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -654,9 +654,10 @@ class WoodyTheme_WoodyGetters
             ],
         ];
         if (!empty($wrapper['display_img'])) {
+            $url = (!empty($sheet_item['img']['url']) && !empty($sheet_item['img']['url']['manual'])) ? str_replace('api.tourism-system.com', 'api.cloudly.space', $sheet_item['img']['url']['manual']) : '';
             $data['img'] = [
                 'resizer' => true,
-                'url' => (!empty($sheet_item['img']['url']) && !empty($sheet_item['img']['url']['manual'])) ? str_replace('api.tourism-system.com', 'api.cloudly.space', $sheet_item['img']['url']['manual']) : '',
+                'url' => !empty($url) ? str_replace('cropratioresize', 'clip', $url) : '',
                 'alt' => (empty($sheet_item['img']['alt'])) ? '' : $sheet_item['img']['alt'],
                 'title' => (empty($sheet_item['img']['title'])) ? '' : $sheet_item['img']['title']
             ];


### PR DESCRIPTION
Sur les MEA, certaines images de fiches SIT sont étirées
<img width="1218" alt="image" src="https://github.com/woody-wordpress/woody-theme/assets/97923256/7a8261f3-a680-4e77-8cf7-41be4f479298">

On applique un remplacement pour changer le crop de l'image dans l'url
<img width="1104" alt="image" src="https://github.com/woody-wordpress/woody-theme/assets/97923256/e8d6b56a-21b7-4285-a3c0-13362362431d">
