### PR TITLE
add contributor field in page teaser

### DIFF
--- a/acf-json/group_5b2bbb46507bf.json
+++ b/acf-json/group_5b2bbb46507bf.json
@@ -180,6 +180,25 @@
             "maxlength": ""
         },
         {
+            "key": "field_662a52cec3b2c",
+            "label": "Contributeur",
+            "name": "page_teaser_contributor",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "25",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
             "key": "field_5b2bbbfaec6b2",
             "label": "Description de la page",
             "name": "page_teaser_desc",


### PR DESCRIPTION
[Ticket des 2 alpes](https://mantis.raccourci.fr/view.php?id=67138)

Ajout d'un field "contributor" dans le page teaser

⚠️ : En lien avec la [MR sur la library](https://git.rc-prod.com/raccourci/woody-wordpress/addons/woody-library/-/merge_requests/810)