### PR TITLE
[TCK0068387|FIX] fix crop ratio on SIT MEA

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -657,7 +657,7 @@ class WoodyTheme_WoodyGetters
             $url = (!empty($sheet_item['img']['url']) && !empty($sheet_item['img']['url']['manual'])) ? str_replace('api.tourism-system.com', 'api.cloudly.space', $sheet_item['img']['url']['manual']) : '';
             $data['img'] = [
                 'resizer' => true,
-                'url' => !empty($url) ? str_replace('cropratioresize', 'clip', $url) : '',
+                'url' => !empty($url) ? str_replace('cropratioresize', 'crop', $url) : '',
                 'alt' => (empty($sheet_item['img']['alt'])) ? '' : $sheet_item['img']['alt'],
                 'title' => (empty($sheet_item['img']['title'])) ? '' : $sheet_item['img']['title']
             ];


### PR DESCRIPTION
Ticket 68387 de Saint gervais

La méthode de crop étirait l'image si le MEA était en portrait ce qui la rendait floue
- Avec la méthode "clip" :
![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/a7244f92-16e4-4539-98e4-d27fc317cbc9)

- Avec la méthode "crop" :
![image](https://github.com/woody-wordpress/woody-theme/assets/97923256/a6c6239c-424b-420b-b796-ac32d3bea8d0)
