### PR TITLE
Bugfix/sheet preview start year

### DIFF
--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -750,6 +750,9 @@ class WoodyTheme_WoodyGetters
                 if ($today < $enddate) {
                     $data['date'] = $date;
                     $data['date']['display_year'] = !empty($date['end']['year']) && $date['end']['year'] > $current_year ? true : false;
+                    if (!empty($data['date']['display_year']) && empty($data['date']['start']['year'])) {
+                        $data['date']['start']['year'] = formatDate($data['date']['start']['startDate'], 'Y');
+                    }
                     break 1 ;
                 }
             }


### PR DESCRIPTION
## bug description
- [Ticket 68824](https://mantis.raccourci.fr/view.php?id=68824)
- [Page exemple](https://douarnenez-tourisme.com/)
- [Fiche](https://douarnenez-tourisme.com/offres/exposition-au-jardin-des-hesperides-douarnenez-fr-4701265/)

![Capture d’écran 2024-06-03 à 16 13 49](https://github.com/woody-wordpress/woody-theme/assets/69916060/13816620-f8b3-4fe6-bacf-028ee42f5de4)

![Capture d’écran 2024-06-03 à 16 13 40](https://github.com/woody-wordpress/woody-theme/assets/69916060/a006f92a-672b-4fcf-b618-d1772eb5e065)

## Correction
![Capture d’écran 2024-06-03 à 15 53 18](https://github.com/woody-wordpress/woody-theme/assets/69916060/6a742ba2-bc84-4c84-9e22-030ad50062cc)
![Capture d’écran 2024-06-03 à 16 13 09](https://github.com/woody-wordpress/woody-theme/assets/69916060/ca2c9d32-9728-4a94-b625-0e6177471a6c)
`if (!empty($data['date']['display_year']) && empty($data['date']['start']['year']))`
