### PR TITLE
Feature/add menus bloc

### DIFF
--- a/acf-json/group_5afd260eeb4ab.json
+++ b/acf-json/group_5afd260eeb4ab.json
@@ -940,6 +940,37 @@
                             ],
                             "min": "",
                             "max": ""
+                        },
+                        "layout_669e145c77a88": {
+                            "key": "layout_669e145c77a88",
+                            "name": "menus",
+                            "label": "Menus",
+                            "display": "block",
+                            "sub_fields": [
+                                {
+                                    "key": "field_64427bab8e1cb",
+                                    "label": "Menus",
+                                    "name": "menus",
+                                    "type": "clone",
+                                    "instructions": "",
+                                    "required": 0,
+                                    "conditional_logic": 0,
+                                    "wrapper": {
+                                        "width": "",
+                                        "class": "hide-label",
+                                        "id": ""
+                                    },
+                                    "clone": [
+                                        "group_669e0870bab60"
+                                    ],
+                                    "display": "seamless",
+                                    "layout": "block",
+                                    "prefix_label": 0,
+                                    "prefix_name": 0
+                                }
+                            ],
+                            "min": "",
+                            "max": ""
                         }
                     },
                     "button_label": "Ajouter un bloc",

--- a/acf-json/group_669e0870bab60.json
+++ b/acf-json/group_669e0870bab60.json
@@ -104,7 +104,7 @@
         {
             "key": "field_669e150e5b394",
             "label": "Bouton(s) supplémentaire(s)",
-            "name": "focus_buttons",
+            "name": "menus_buttons",
             "type": "clone",
             "instructions": "",
             "required": 0,
@@ -140,7 +140,7 @@
         {
             "key": "field_669e151e1e24d",
             "label": "Personnalisation du fond",
-            "name": "focus_block_title_bg_params",
+            "name": "menus_block_title_bg_params",
             "type": "clone",
             "instructions": "",
             "required": 0,
@@ -159,7 +159,7 @@
         {
             "key": "field_669e152d9775d",
             "label": "Afficher le titre en pleine largeur",
-            "name": "focus_block_title_fullwidth",
+            "name": "menus_block_title_fullwidth",
             "type": "true_false",
             "instructions": "",
             "required": 0,
@@ -281,7 +281,7 @@
         {
             "key": "field_669e158607ca4",
             "label": "Paramètres de fond",
-            "name": "focus_block_bg_params",
+            "name": "menus_block_bg_params",
             "type": "clone",
             "instructions": "",
             "required": 0,
@@ -300,7 +300,7 @@
         {
             "key": "field_669e159576e6c",
             "label": "Retirer les marges autour des mises en avant",
-            "name": "focus_no_padding",
+            "name": "menus_no_padding",
             "type": "true_false",
             "instructions": "",
             "required": 0,

--- a/acf-json/group_669e0870bab60.json
+++ b/acf-json/group_669e0870bab60.json
@@ -1,0 +1,445 @@
+{
+    "key": "group_669e0870bab60",
+    "title": "Menus",
+    "fields": [
+        {
+            "key": "field_669e14e7c3957",
+            "label": "Contenu",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e17f6ced03",
+            "label": "Menu à afficher",
+            "name": "menu_type",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+            },
+            "default_value": "link",
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 0,
+            "return_format": "value",
+            "ajax": 0,
+            "placeholder": ""
+        },
+        {
+            "key": "field_669e14f4075e4",
+            "label": "FIN",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 1
+        },
+        {
+            "key": "field_669e14fc74e5e",
+            "label": "Titre du bloc",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e1503cdb80",
+            "label": "Titre du bloc",
+            "name": "menus_block_title",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": [
+                "field_5b041d61adb72",
+                "field_5b041c6aadb71",
+                "field_5b041d79adb73",
+                "field_5b59bbd0e094c",
+                "field_5b72f56b6f4aa",
+                "field_5b59bc12e094d",
+                "field_5b041dbfadb74"
+            ],
+            "display": "seamless",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 0
+        },
+        {
+            "key": "field_669e150e5b394",
+            "label": "Bouton(s) supplémentaire(s)",
+            "name": "focus_buttons",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": ["group_5b043614df4a6"],
+            "display": "group",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 1
+        },
+        {
+            "key": "field_669e15173ced8",
+            "label": "Options avancées",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 1,
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e151e1e24d",
+            "label": "Personnalisation du fond",
+            "name": "focus_block_title_bg_params",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": ["group_5b043c93d609a"],
+            "display": "group",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 1
+        },
+        {
+            "key": "field_669e152d9775d",
+            "label": "Afficher le titre en pleine largeur",
+            "name": "focus_block_title_fullwidth",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_669e15330d6c9",
+            "label": "FIN",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 1
+        },
+        {
+            "key": "field_669e153e40605",
+            "label": "Mise en page",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e1544674fb",
+            "label": "Template",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 1,
+            "multi_expand": 1,
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e154ce5fac",
+            "label": "Template",
+            "name": "woody_tpl",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "hide-label",
+                "id": ""
+            },
+            "default_value": "blocks-menus-tpl_601",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "button_field_669e154ce5fac",
+            "label": "Choisir une mise en page",
+            "name": "",
+            "type": "message",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "hide-label woody-tpl-button group_669e0870bab60",
+                "id": ""
+            },
+            "message": "Choisir une mise en page",
+            "new_lines": "wpautop",
+            "esc_html": 0
+        },
+        {
+            "key": "field_669e15808773d",
+            "label": "Options avancées",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 1,
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e158607ca4",
+            "label": "Paramètres de fond",
+            "name": "focus_block_bg_params",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": ["group_5b043c93d609a"],
+            "display": "group",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 1
+        },
+        {
+            "key": "field_669e159576e6c",
+            "label": "Retirer les marges autour des mises en avant",
+            "name": "focus_no_padding",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_669e159bc27d2",
+            "label": "Effets visuels",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e15a39d8a3",
+            "label": "Effets visuels",
+            "name": "visual_effects",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": ["group_5bc845beeae52"],
+            "display": "seamless",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 0
+        },
+        {
+            "key": "field_669e15ac1f2d5",
+            "label": "FIN",
+            "name": "",
+            "type": "accordion",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "open": 0,
+            "multi_expand": 0,
+            "endpoint": 1
+        },
+        {
+            "key": "field_669e15b3d9173",
+            "label": "Responsive",
+            "name": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_669e15bb234e6",
+            "label": "Afficher le bloc",
+            "name": "",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": ["group_61d30e86c3313"],
+            "display": "seamless",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 0
+        },
+        {
+            "key": "field_669e15c26d475",
+            "label": "Comportement mobile",
+            "name": "mobile_behaviour",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "hide-label",
+                "id": ""
+            },
+            "clone": ["group_5efca9579270c"],
+            "display": "group",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 1
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "Bloc récupérant le contenu des menus",
+    "modified": 1641315307
+}

--- a/library/classes/acf/class-acf.php
+++ b/library/classes/acf/class-acf.php
@@ -630,6 +630,28 @@ class WoodyTheme_ACF
             unset($field['layouts']['layout_infolive']);
         }
 
+        if (in_array('menus_v2', WOODY_OPTIONS)) {
+            // On complète la liste de menu dans le backoffice
+            if (!empty($field['layouts']['layout_669e145c77a88']['sub_fields'])) {
+                foreach ($field['layouts']['layout_669e145c77a88']['sub_fields'] as $menu_field_key => $menu_field) {
+                    if ($menu_field['name'] == "menu_type") {
+                        $registerMenusClass = new \Woody\Addon\Menus\Services\RegisterMenus();
+                        $menus = $registerMenusClass->setPagesOptions();
+                        
+                        if (!empty($menus['sub_pages'])) {
+                            foreach ($menus['sub_pages'] as $subpage_key => $subpage) {
+                                if ($subpage['translate_type'] != "tree_menu") {
+                                    $field['layouts']['layout_669e145c77a88']['sub_fields'][$menu_field_key]['choices'][$subpage_key] = $subpage['menu_title'];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            unset($field['layouts']['layout_669e145c77a88']);
+        }
+
         return $field;
     }
 
@@ -1154,6 +1176,9 @@ class WoodyTheme_ACF
                 'blocks-summary-tpl_01',
                 'blocks-summary-tpl_03',
                 'blocks-summary-tpl_02',
+            ],
+            'menus' => [
+                'blocks-menu-tpl_01'
             ]
         ];
 

--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -245,6 +245,7 @@ class WoodyTheme_WoodyProcess
                 break;
             case 'quote':
                 $layout['display'] = $this->tools->getDisplayOptions($layout['quote_bg_params']);
+                console_log($layout);
                 $return = \Timber::compile($context['woody_components'][$layout['woody_tpl']], $layout);
                 break;
             case 'feature':
@@ -305,6 +306,15 @@ class WoodyTheme_WoodyProcess
                 break;
             case 'timeline':
                 $layout['display'] = $this->tools->getDisplayOptions($layout['timeline_bg_params']);
+                $return = \Timber::compile($context['woody_components'][$layout['woody_tpl']], $layout);
+                break;
+            case 'menus':
+                $current_lang = function_exists('pll_current_language') ? pll_current_language() : 'fr';
+                $layout['block_titles'] = $this->tools->getBlockTitles($layout);
+                if (!empty($layout['menu_type'])) {
+                    $menu_content = get_field(sprintf("%s_%s", $layout['menu_type'], $current_lang), 'options');
+                    $layout['items'] = !empty($menu_content['links']) ? $menu_content['links'] : '';
+                }
                 $return = \Timber::compile($context['woody_components'][$layout['woody_tpl']], $layout);
                 break;
             default:

--- a/library/classes/process/class-woody-process.php
+++ b/library/classes/process/class-woody-process.php
@@ -309,11 +309,15 @@ class WoodyTheme_WoodyProcess
                 $return = \Timber::compile($context['woody_components'][$layout['woody_tpl']], $layout);
                 break;
             case 'menus':
-                $current_lang = function_exists('pll_current_language') ? pll_current_language() : 'fr';
+                $layout['display'] = $this->tools->getDisplayOptions($layout['menus_block_bg_params']);
                 $layout['block_titles'] = $this->tools->getBlockTitles($layout);
+                $current_lang = function_exists('pll_current_language') ? pll_current_language() : 'fr';
+
                 if (!empty($layout['menu_type'])) {
                     $menu_content = get_field(sprintf("%s_%s", $layout['menu_type'], $current_lang), 'options');
-                    $layout['items'] = !empty($menu_content['links']) ? $menu_content['links'] : '';
+                    // Le filtre permet de modifier le wrapper qui englobe les liens
+                    $items = apply_filters('woody_section_menu_modifier', $menu_content["links"], $layout['menu_type'], $menu_content);
+                    $layout['items'] = !empty($items) ? $items : '';
                 }
                 $return = \Timber::compile($context['woody_components'][$layout['woody_tpl']], $layout);
                 break;

--- a/src/scss/admin/acf.scss
+++ b/src/scss/admin/acf.scss
@@ -1024,6 +1024,11 @@
                     }
                 }
 
+                &[data-layout='menus'] {
+                    &:before {
+                        content: '\f333';
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Ajout d'un bloc Menus.

Il permet d'afficher le contenu des menus (si le "translate_type" est différent de "tree_menu" pour exclure le menu principal).

On ajoute dynamiquement les menus dans le bloc (dans le BO) en passant par la class-acf.php du thème. Pour ça on récupère les menus via la fonction setPagesOptions() de l'addon menu.

⚠️ Le bloc est donc visible seulement si les menus V2 sont activés

Les menus avec les clé acf "link" et "link_icons" ont les liens englobés dans une entrée "links". Or pour un menu custom, un traitement en conséquence est nécessaire. On peut donc ce brancher sur le filtre `woody_section_menu_modifier` pour modifier/mapper les données pour qu'elles collent avec l'affichage :

```php
links [
    [] => [
        "woody_icon" => "",
        "link" => ["title", "url", "target"]
    ],
    ...
] 
```