### PR TITLE
[fix] include array of all selected terms in wp query

### DIFF
--- a/library/classes/process/class-woody-process-tools.php
+++ b/library/classes/process/class-woody-process-tools.php
@@ -270,14 +270,13 @@ class WoodyTheme_WoodyProcessTools
             }
         }
 
-
         $query_results = new \WP_Query(array(
             'posts_per_page'    => $limit,
             'post_type'         => 'attachment',
             'post_status'       => 'inherit',
             'tax_query'         => array(
                 'relation' =>  $andor,
-                $tax_query[0]
+                $tax_query
             )
         ));
 


### PR DESCRIPTION
##  Bug example
- [Blois chambord - section 2](https://m.bloischambord.com/decouvrir-la-destination/nos-chateaux-de-la-loire/le-chateau-de-blois/)
### Query bug
<img width="706" alt="Capture d’écran 2024-09-13 à 15 28 58" src="https://github.com/user-attachments/assets/3b307037-b268-4d2f-a76d-f366a333dd03">
### Back office bug
<img width="941" alt="Capture d’écran 2024-09-13 à 15 30 33" src="https://github.com/user-attachments/assets/39f039d6-ab45-4081-b60f-1be597b1d444">
### Query Fix
<img width="706" alt="Capture d’écran 2024-09-13 à 15 29 52" src="https://github.com/user-attachments/assets/c5845495-965b-460b-95f6-0f800a2ef0b0">
### Back office fix
<img width="941" alt="Capture d’écran 2024-09-13 à 15 30 23" src="https://github.com/user-attachments/assets/2ae16acc-9ce6-4c2a-a6f4-26bace4b9239">

