### PR TITLE
display none bookblock in BO

### DIFF
--- a/src/scss/admin/acf.scss
+++ b/src/scss/admin/acf.scss
@@ -1170,3 +1170,8 @@
 .acf-field-6061dcdfc96ee {
     overflow: scroll;
 }
+
+// Bloc de réservation dans les pages d'accueil
+#acf-group_5c0e4121ee3ed {
+    display: none !important;
+}


### PR DESCRIPTION
Masquage du "Bloc de réservation" dans le BO

Depuis l'ajout du bloc "Formulaire de réservation" disponible dans les sections, le bloc de résa est obsolète. De plus, il nécessite une surcharge de style pour qu'il soit visible et n'est pas adapté à tous les templates de landswpr.

Le masquage en SCSS évitera qu'il soit de nouveau utiliser sans impacter les sites utilisant cette fonctionnalité