### PR TITLE
[ACCESS] re-order DOM

### DIFF
--- a/views/base.twig
+++ b/views/base.twig
@@ -80,6 +80,14 @@
     {% endif %}
 
     <div class="main-wrapper flex-container flex-dir-column {{ not globals.is_mobile ? 'flex-dir-column-reverse' : '' }}">
+        {# Theme Header #}
+        {% block page_header %}
+        {% if 'header' not in hide_page_zones %}
+        {% include 'parts/header.twig' %}
+        {% endif %}
+        {% endblock %}
+        {# /Theme Header #}
+        
         <div class="site-content">
             {# Theme Content #}
             {% block content %}{% endblock %}
@@ -93,14 +101,6 @@
             {% endblock %}
             {# /Theme Footer #}
         </div>
-
-        {# Theme Header #}
-        {% block page_header %}
-        {% if 'header' not in hide_page_zones %}
-        {% include 'parts/header.twig' %}
-        {% endif %}
-        {% endblock %}
-        {# /Theme Header #}
 
         {% if woody_access_staging %}
         <div class="staging-banner">


### PR DESCRIPTION
Traduction des aria-label des flèches de swiper en JS.
Traductions faites en Français, Allemand, Italien, Néerlandais, Anglais (default)

Ordonnancement du DOM
Le header remonte au dessus du DOM
Suppression de la classe `flex-dir-column-reverse`
Les sites actuels ont leur header en `fixed`, niveau front, ça ne change rien sur ces sites. Pour les autres, la suppression de la classe `flex-dir-column-reverse` permet de laisser le header au dessus du contenu du site