### PR TITLE
[style] reponsive options colors back-office

### DIFF
--- a/src/scss/admin/acf.scss
+++ b/src/scss/admin/acf.scss
@@ -1057,9 +1057,13 @@
 }
 
 // Retour à la ligne des options de couleur de fond dans Options avancées => Couleur de fond
+// Retour à la ligne des options de couleur de bouton dans Options avancées => Couleur de bouton
+// Retour à la ligne des options de couleur de bordure dans Options avancées => Couleur de bordure
 // Retour à la ligne des options de marge intérieure dans Options avancées => Marge intérieure
 .acf-field-5b043ca4a6fe3,
-.acf-field-61dc59647cc82 {
+.acf-field-61dc59647cc82,
+.acf-field-5c79387a6526b,
+.acf-field-5b978a13feaa6 {
     .acf-button-group {
         flex-wrap: wrap;
 


### PR DESCRIPTION
Ajouter un flex-wrap sur les options de couleurs pour les boutons et les bordures afin d'éviter un débordement dans le back-office