### PR TITLE
[feat] add fav icon on MEA

### DIFF
--- a/acf-json/group_5b0d1ed32a384.json
+++ b/acf-json/group_5b0d1ed32a384.json
@@ -451,7 +451,8 @@
                 "_places": "Lieu principal(e)",
                 "_seasons": "Circonstance principal(e)",
                 "_targets": "Cible principal(e)",
-                "created": "Date de publication"
+                "created": "Date de publication",
+                "favorites": "Favoris"
             },
             "allow_custom": 0,
             "default_value": [

--- a/acf-json/group_5b2788b48d04c.json
+++ b/acf-json/group_5b2788b48d04c.json
@@ -265,7 +265,8 @@
                 "_places": "Lieu principal(e)<\/small>",
                 "_seasons": "Circonstance principal(e)<\/small>",
                 "_targets": "Cible principal(e)<\/small>",
-                "created": "Date de publication"
+                "created": "Date de publication",
+                "favorites": "Favoris"
             },
             "allow_custom": 0,
             "default_value": [],

--- a/library/classes/process/class-woody-getters.php
+++ b/library/classes/process/class-woody-getters.php
@@ -644,6 +644,11 @@ class WoodyTheme_WoodyGetters
                 }
             }
 
+            // Ajout du coeur de favoris
+            if (in_array('favorites', $wrapper['display_elements'])) {
+                $data['favorites'] = true;
+            }
+
             foreach ($wrapper['display_elements'] as $display) {
                 if (strpos($display, '_') === 0) {
                     $tax = ltrim($display, '_');
@@ -813,6 +818,11 @@ class WoodyTheme_WoodyGetters
             $data['movie'] = $item['movie'];
         }
 
+        // Ajout du coeur de favoris
+        if (in_array('favorites', $wrapper['display_elements'])) {
+            $data['favorites'] = true;
+        }
+
         $data['cardDisplayOptions'] = $wrapper['display_elements'];
 
         return $data;
@@ -925,6 +935,11 @@ class WoodyTheme_WoodyGetters
                         'text' => __('Appeler', 'woody-theme')
                     ];
                 }
+            }
+
+            // Ajout du coeur de favoris
+            if (in_array('favorites', $wrapper['display_elements'])) {
+                $data['favorites'] = true;
             }
 
             if (in_array('website', $wrapper['display_elements'])) {


### PR DESCRIPTION
Pour le développement de Dunkerque, il y a un coeur de favoris directement sur les card de mise en avant, comme c'est le cas sur les MEA YouBook

On peut donc désormais, dans le backoffice les blocs de MEA (manuel, auto SIT et auto Page) cocher la case "Favoris" pour faire apparaître le coeur de favoris sur les cards.

:warning: Cette MR est liée à celle sur [l'addon Hawwwai](https://git.rc-prod.com/raccourci/woody-wordpress/addons/woody-addon-hawwwai/-/merge_requests/104) et celle sur la [library](https://git.rc-prod.com/raccourci/woody-wordpress/addons/woody-library/-/merge_requests/928)