### PR TITLE
[FEATURE|RGAA] add aria label on content list pagination

### DIFF
--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -577,7 +577,36 @@ class WoodyTheme_WoodyCompilers
             'mid_size' => 3,
             'type' => 'list'
         ];
+
+        $pager_output = paginate_links($pager_args);
+        add_filter('paginate_links_output', [$this, 'links_output_aria_element'], $pager_output);
+
         return paginate_links($pager_args);
+    }
+
+    public function links_output_aria_element($pager_output) {
+        // Ajout d'un aria-label="Page X" pour chaque lien de pagination
+        $pager_output = preg_replace_callback(
+            '/<a([^>]*)href=["\']([^"\']+)["\']([^>]*)>(\d+)<\/a>/',
+            function ($matches) {
+                $aria_label = ' aria-label="' . __("Page", "woody-theme") . ' ' . $matches[4] . '"';
+                return '<a' . $matches[1] . ' href="' . $matches[2] . '"' . $aria_label . $matches[3] . '>' . $matches[4] . '</a>';
+            },
+            $pager_output
+        );
+
+        // Ajouter aria-label pour "Précédent" et "Suivant"
+        $pager_output = preg_replace_callback(
+            '/<a([^>]*)href=["\']([^"\']+)["\']([^>]*)>(«\s*Précédent|Suivant\s*»)<\/a>/u',
+            function ( $matches ) {
+                $label = (strpos($matches[4], 'Précédent') !== false) ? __("Page précédente", "woody-theme") : __("Page suivante", "woody-theme");
+                $aria_label = ' aria-label="' . $label . '"';
+                return '<a' . $matches[1] . ' href="' . $matches[2] . '"' . $aria_label . $matches[3] . '>' . $matches[4] . '</a>';
+            },
+            $pager_output
+        );
+
+        return $pager_output;
     }
 
     /**

--- a/library/classes/process/class-woody-compilers.php
+++ b/library/classes/process/class-woody-compilers.php
@@ -578,8 +578,8 @@ class WoodyTheme_WoodyCompilers
             'type' => 'list'
         ];
 
+        add_filter('paginate_links_output', [$this, 'links_output_aria_element']);
         $pager_output = paginate_links($pager_args);
-        add_filter('paginate_links_output', [$this, 'links_output_aria_element'], $pager_output);
 
         return paginate_links($pager_args);
     }


### PR DESCRIPTION
En raison du RGAA, on doit ajouter un attribut `aria-label="Page X"` à la pagination des listes de contenu.

On utilise une fonction native de Wordpress pour générer la pagination (`paginate_links`). En utilisant le hook `paginate_links_output` on peut récupérer la compilation HTML sous forme de string et faire des changements.

A partir d'une regex, on peut récupérer les liens et ajouter le aria-label et le remplir avec le contenu du lien.
J'ai également fait la modification pour récupérer le "Page précédente" et "Page suivante"

On obtient le HTML suivant

```html
<ul class='page-numbers'>
	<li><a class="prev page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/" aria-label="Page précédente">« Précédent</a></li>
	<li><a class="page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/" aria-label="Page 1">1</a></li>
	<li><span aria-current="page" class="page-numbers current">2</span></li>
	<li><a class="page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/?s0sc0=3&#038;seed=04032025" aria-label="Page 3">3</a></li>
	<li><a class="page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/?s0sc0=4&#038;seed=04032025" aria-label="Page 4">4</a></li>
	<li><a class="page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/?s0sc0=5&#038;seed=04032025" aria-label="Page 5">5</a></li>
	<li><span class="page-numbers dots">…</span></li>
	<li><a class="page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/?s0sc0=16&#038;seed=04032025" aria-label="Page 16">16</a></li>
	<li><a class="next page-numbers"  href="http://www.dunkerque.wp.rc-dev.com/rgaa/?s0sc0=3&#038;seed=04032025" aria-label="Page suivante">Suivant »</a></li>
</ul>
```